### PR TITLE
Add support for Environment files

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,65 @@ GET {{baseUrl}}/api/search/tool
 
 **Note:** Variables must be defined before they can be used. The order of definition matters.
 
+## Environment Files
+
+To give variables different values in different environments, create a file named `http-client.env.json`. This file should be located in the same directory as the `.http` file or in one of its parent directories.
+
+### Environment File Format
+
+The environment file is a JSON file that contains one or more named environments. Here's an example:
+
+```json
+{
+  "dev": {
+    "HostAddress": "https://localhost:44320",
+    "ApiKey": "dev-api-key-123",
+    "Environment": "development"
+  },
+  "staging": {
+    "HostAddress": "https://staging.contoso.com",
+    "ApiKey": "staging-api-key-456",
+    "Environment": "staging"
+  },
+  "prod": {
+    "HostAddress": "https://contoso.com",
+    "ApiKey": "prod-api-key-789", 
+    "Environment": "production"
+  }
+}
+```
+
+### Using Environment Variables
+
+Variables from an environment file are referenced the same way as other variables:
+
+```http
+# This will use the HostAddress from the specified environment
+GET {{HostAddress}}/api/search/tool
+Authorization: Bearer {{ApiKey}}
+X-Environment: {{Environment}}
+```
+
+### Specifying Environment
+
+Use the `--env` flag to specify which environment to use:
+
+```bash
+# Use development environment
+httprunner myfile.http --env dev
+
+# Use production environment  
+httprunner myfile.http --env prod
+```
+
+### Variable Override Behavior
+
+If a variable is defined in both the `.http` file and the environment file:
+
+- **Environment variables** are loaded first
+- **Variables in .http file** override environment variables with the same name
+- This allows you to have environment defaults while still being able to override them per request file
+
 ## Response Assertions
 
 The HTTP File Runner supports assertions to validate HTTP responses. You can assert on status codes, response body content, and response headers.

--- a/examples/environment-variables.http
+++ b/examples/environment-variables.http
@@ -1,0 +1,24 @@
+# Environment Variables Example
+# This file demonstrates how to use environment variables
+
+@DefaultHost=httpbin.org
+
+# Simple requests using environment variables
+GET https://{{HostAddress}}/api/search/tool
+Accept: application/json
+X-Environment: {{Environment}}
+
+# Request using both environment and local variables
+GET https://{{HostAddress}}/status/200
+Authorization: Bearer {{ApiKey}}
+X-Host: {{DefaultHost}}
+
+# POST request with environment variables in body
+POST https://{{HostAddress}}/post
+Content-Type: application/json
+
+{
+  "environment": "{{Environment}}",
+  "host": "{{HostAddress}}",
+  "apiKey": "{{ApiKey}}"
+}

--- a/examples/http-client.env.json
+++ b/examples/http-client.env.json
@@ -1,0 +1,17 @@
+{
+  "dev": {
+    "HostAddress": "httpbin.org",
+    "ApiKey": "dev-api-key-123",
+    "Environment": "development"
+  },
+  "staging": {
+    "HostAddress": "httpbin.org",
+    "ApiKey": "staging-api-key-456",
+    "Environment": "staging"
+  },
+  "prod": {
+    "HostAddress": "httpbin.org",
+    "ApiKey": "prod-api-key-789",
+    "Environment": "production"
+  }
+}

--- a/src/environment.zig
+++ b/src/environment.zig
@@ -1,0 +1,141 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const types = @import("types.zig");
+const Variable = types.Variable;
+
+const EnvironmentConfig = struct {
+    environments: std.StringHashMap(std.StringHashMap([]const u8)),
+
+    pub fn init(allocator: Allocator) EnvironmentConfig {
+        return EnvironmentConfig{
+            .environments = std.StringHashMap(std.StringHashMap([]const u8)).init(allocator),
+        };
+    }
+
+    pub fn deinit(self: *EnvironmentConfig, allocator: Allocator) void {
+        var env_iterator = self.environments.iterator();
+        while (env_iterator.next()) |env_entry| {
+            var var_iterator = env_entry.value_ptr.iterator();
+            while (var_iterator.next()) |var_entry| {
+                allocator.free(var_entry.key_ptr.*);
+                allocator.free(var_entry.value_ptr.*);
+            }
+            env_entry.value_ptr.deinit();
+            allocator.free(env_entry.key_ptr.*);
+        }
+        self.environments.deinit();
+    }
+};
+
+pub fn loadEnvironmentFile(allocator: Allocator, http_file_path: []const u8, environment_name: ?[]const u8) !std.ArrayList(Variable) {
+    var variables = std.ArrayList(Variable).init(allocator);
+
+    if (environment_name == null) {
+        return variables;
+    }
+
+    const env_file_path = try findEnvironmentFile(allocator, http_file_path);
+    defer if (env_file_path) |path| allocator.free(path);
+
+    if (env_file_path == null) {
+        return variables;
+    }
+
+    const env_config = parseEnvironmentFile(allocator, env_file_path.?) catch {
+        // If we can't parse the environment file, just return empty variables
+        // This allows the tool to continue working even if the env file has issues
+        return variables;
+    };
+    defer {
+        var config = env_config;
+        config.deinit(allocator);
+    }
+
+    // Get variables for the specified environment
+    if (env_config.environments.get(environment_name.?)) |env_vars| {
+        var iterator = env_vars.iterator();
+        while (iterator.next()) |entry| {
+            try variables.append(.{
+                .name = try allocator.dupe(u8, entry.key_ptr.*),
+                .value = try allocator.dupe(u8, entry.value_ptr.*),
+            });
+        }
+    }
+
+    return variables;
+}
+
+fn findEnvironmentFile(allocator: Allocator, http_file_path: []const u8) !?[]const u8 {
+    // Start from the directory containing the .http file
+    const dirname = std.fs.path.dirname(http_file_path) orelse ".";
+
+    var current_dir = try allocator.dupe(u8, dirname);
+    defer allocator.free(current_dir);
+
+    while (true) {
+        const env_file_path = try std.fs.path.join(allocator, &[_][]const u8{ current_dir, "http-client.env.json" });
+        defer allocator.free(env_file_path);
+
+        // Check if the file exists
+        if (std.fs.cwd().access(env_file_path, .{})) |_| {
+            return try allocator.dupe(u8, env_file_path);
+        } else |_| {
+            // File doesn't exist, try parent directory
+            const parent_dir = std.fs.path.dirname(current_dir);
+            if (parent_dir == null or std.mem.eql(u8, parent_dir.?, current_dir)) {
+                // Reached root directory
+                break;
+            }
+
+            const new_current_dir = try allocator.dupe(u8, parent_dir.?);
+            allocator.free(current_dir);
+            current_dir = new_current_dir;
+        }
+    }
+
+    return null;
+}
+
+fn parseEnvironmentFile(allocator: Allocator, file_path: []const u8) !EnvironmentConfig {
+    const file = try std.fs.cwd().openFile(file_path, .{});
+    defer file.close();
+
+    const file_size = try file.getEndPos();
+    const content = try allocator.alloc(u8, file_size);
+    defer allocator.free(content);
+    _ = try file.readAll(content);
+
+    var config = EnvironmentConfig.init(allocator);
+
+    const parsed = std.json.parseFromSlice(std.json.Value, allocator, content, .{}) catch |err| {
+        return err;
+    };
+    defer parsed.deinit();
+
+    const root = parsed.value;
+    if (root != .object) {
+        return error.InvalidEnvironmentFile;
+    }
+
+    var env_iterator = root.object.iterator();
+    while (env_iterator.next()) |env_entry| {
+        const env_name = try allocator.dupe(u8, env_entry.key_ptr.*);
+        var env_vars = std.StringHashMap([]const u8).init(allocator);
+
+        if (env_entry.value_ptr.* == .object) {
+            var var_iterator = env_entry.value_ptr.object.iterator();
+            while (var_iterator.next()) |var_entry| {
+                const var_name = try allocator.dupe(u8, var_entry.key_ptr.*);
+                const var_value = switch (var_entry.value_ptr.*) {
+                    .string => |s| try allocator.dupe(u8, s),
+                    else => try allocator.dupe(u8, ""), // Convert non-strings to empty string
+                };
+                try env_vars.put(var_name, var_value);
+            }
+        }
+
+        try config.environments.put(env_name, env_vars);
+    }
+
+    return config;
+}

--- a/src/main.zig
+++ b/src/main.zig
@@ -31,9 +31,9 @@ pub fn main() !void {
         }
         const found_files = try discovery.runDiscoveryMode(allocator, &discovered_files);
         if (found_files) {
-            try processor.processHttpFiles(allocator, discovered_files.items, options.verbose, options.log_file);
+            try processor.processHttpFiles(allocator, discovered_files.items, options.verbose, options.log_file, options.environment);
         }
     } else {
-        try processor.processHttpFiles(allocator, options.files, options.verbose, options.log_file);
+        try processor.processHttpFiles(allocator, options.files, options.verbose, options.log_file, options.environment);
     }
 }

--- a/src/processor.zig
+++ b/src/processor.zig
@@ -11,7 +11,7 @@ const Log = @import("log.zig").Log;
 
 const HttpRequest = types.HttpRequest;
 
-pub fn processHttpFiles(allocator: Allocator, files: []const []const u8, verbose: bool, log_filename: ?[]const u8) !void {
+pub fn processHttpFiles(allocator: Allocator, files: []const []const u8, verbose: bool, log_filename: ?[]const u8, environment: ?[]const u8) !void {
     var log = Log.init(allocator, log_filename) catch |err| {
         print("{s}❌ Error initializing log: {}{s}\n", .{ colors.RED, err, colors.RESET });
         return err;
@@ -26,7 +26,7 @@ pub fn processHttpFiles(allocator: Allocator, files: []const []const u8, verbose
         log.write("{s}🚀 HTTP File Runner - Processing file: {s}{s}\n", .{ colors.BLUE, http_file, colors.RESET });
         log.write("{s}\n", .{"=" ** 50});
 
-        const requests = parser.parseHttpFile(allocator, http_file) catch |err| {
+        const requests = parser.parseHttpFile(allocator, http_file, environment) catch |err| {
             switch (err) {
                 error.FileNotFound => {
                     log.write("{s}❌ Error: File '{s}' not found{s}\n", .{ colors.RED, http_file, colors.RESET });


### PR DESCRIPTION
This pull request introduces support for environment variables in the HTTP File Runner, allowing users to define and manage variables across different environments. The changes span multiple files, adding functionality to specify environments via a new `--env` CLI flag, load environment-specific variables from a JSON file, and integrate these variables into HTTP requests. Below is a breakdown of the most important changes grouped by theme.

### Environment Variable Support

* **Environment file documentation**: Added a section in `README.md` explaining how to create and use `http-client.env.json` files to define environment-specific variables, including examples and override behavior.
* **Environment file examples**: Added example files `examples/environment-variables.http` and `examples/http-client.env.json` to demonstrate the usage of environment variables in HTTP requests. [[1]](diffhunk://#diff-562f07656406b4206be40ae724b5fc6525507d116897685d1c10ddf771f33773R1-R24) [[2]](diffhunk://#diff-4b3b4987def28bc98f4c9ed9f291409fad6a3abc5c95353652fdeff5ddb9f1b1R1-R17)

### CLI Enhancements

* **New `--env` flag**: Updated `src/cli.zig` to support the `--env` flag, enabling users to specify the environment name for loading variables. Added logic to parse this flag and pass the environment name to other components. [[1]](diffhunk://#diff-0213d803b050248119f629ea8f3e9dc3a9dd5fc1c78cd3176ccdabebb6a1b4e7R11) [[2]](diffhunk://#diff-0213d803b050248119f629ea8f3e9dc3a9dd5fc1c78cd3176ccdabebb6a1b4e7R30-R51) [[3]](diffhunk://#diff-0213d803b050248119f629ea8f3e9dc3a9dd5fc1c78cd3176ccdabebb6a1b4e7R68-R72) [[4]](diffhunk://#diff-0213d803b050248119f629ea8f3e9dc3a9dd5fc1c78cd3176ccdabebb6a1b4e7R122-R145)

### Environment File Parsing

* **Environment file loader**: Added `src/environment.zig` to handle loading, parsing, and managing environment-specific variables from `http-client.env.json`. Includes functionality to traverse directories, parse JSON, and deallocate resources.

### Integration with HTTP File Parsing

* **Environment variable injection**: Modified `src/parser.zig` to load environment variables and integrate them with local variables in HTTP files. Environment variables are overridden by local variables when conflicts occur. [[1]](diffhunk://#diff-d74dadc57efeb3cad49ee4c0fde55a998975a9a83ca52698ca53b1d51eb46220R4-R9) [[2]](diffhunk://#diff-d74dadc57efeb3cad49ee4c0fde55a998975a9a83ca52698ca53b1d51eb46220R20-R47) [[3]](diffhunk://#diff-d74dadc57efeb3cad49ee4c0fde55a998975a9a83ca52698ca53b1d51eb46220R68-R87)

### Processor Updates

* **Environment-aware processing**: Updated `src/processor.zig` and `src/main.zig` to pass the environment name to the HTTP file parser, ensuring environment variables are included during request processing. [[1]](diffhunk://#diff-fccd5b72660d24c584d7283be9a093fece151f4d47d59f133ed89dc6079a5e57L14-R14) [[2]](diffhunk://#diff-fccd5b72660d24c584d7283be9a093fece151f4d47d59f133ed89dc6079a5e57L29-R29) [[3]](diffhunk://#diff-d924ca21d81d7d5a59eb9e10d3e2689c4c58a7e28e6ecce6a064701666f5a730L34-R37)