### PR TITLE
Introduce --upgrade argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,47 @@ The httprunner is available as a Docker image on Docker Hub at `christianhelle/h
 docker pull christianhelle/httprunner
 ```
 
+## Upgrading
+
+### Quick Upgrade
+
+If you have httprunner already installed, you can easily upgrade to the latest version using the built-in upgrade command:
+
+```bash
+# Upgrade to the latest version
+httprunner --upgrade
+```
+
+The upgrade command will:
+
+- Automatically detect your platform (Windows, Linux, macOS)
+- Download and run the appropriate install script
+- Update httprunner to the latest version available
+- Preserve your existing installation location
+
+**What it runs under the hood:**
+
+- **Linux/macOS:** `curl -fsSL https://christianhelle.com/httprunner/install | bash`
+- **Windows:** `irm https://christianhelle.com/httprunner/install.ps1 | iex`
+
+After upgrading, you may need to restart your terminal to use the updated version.
+
+### Manual Upgrade
+
+Alternatively, you can always re-run the installation scripts manually:
+
+**Linux/macOS:**
+
+```bash
+curl -fsSL https://christianhelle.com/httprunner/install | bash
+```
+
+**Windows (PowerShell):**
+
+```powershell
+irm https://christianhelle.com/httprunner/install.ps1 | iex
+```
+
 ## Usage
 
 ### If installed via Snap

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -20,6 +20,12 @@ pub const CliOptions = struct {
         }
     }
     pub fn parse(allocator: Allocator, args: []const []const u8) !CliOptions {
+        // Check for help flag first
+        if (containsFlag(args, "--help") or containsFlag(args, "-h")) {
+            showUsage();
+            return error.InvalidArguments;
+        }
+
         // Check for version flag first
         if (containsFlag(args, "--version") or containsFlag(args, "-v")) {
             return CliOptions{
@@ -72,7 +78,9 @@ pub const CliOptions = struct {
             if (std.mem.eql(u8, arg, "--discover") or
                 std.mem.eql(u8, arg, "--verbose") or
                 std.mem.eql(u8, arg, "--version") or
-                std.mem.eql(u8, arg, "-v"))
+                std.mem.eql(u8, arg, "--help") or
+                std.mem.eql(u8, arg, "-v") or
+                std.mem.eql(u8, arg, "-h"))
             {
                 continue;
             } else if (std.mem.eql(u8, arg, "--log")) {
@@ -154,6 +162,7 @@ pub fn showUsage() void {
     print("  httprunner <http-file> [http-file2] [...] [--verbose] [--log [filename]] [--env <environment>]\n", .{});
     print("  httprunner [--verbose] [--log [filename]] [--env <environment>] --discover\n", .{});
     print("  httprunner --version | -v\n", .{});
+    print("  httprunner --help | -h\n", .{});
     print("\n{s}Arguments:{s}\n", .{ colors.BLUE, colors.RESET });
     print("  <http-file>    One or more .http files to process\n", .{});
     print("  --discover     Recursively discover and process all .http files from current directory\n", .{});
@@ -161,6 +170,7 @@ pub fn showUsage() void {
     print("  --log [file]   Log output to a file (defaults to 'log' if no filename is specified)\n", .{});
     print("  --env <env>    Specify environment name to load variables from http-client.env.json\n", .{});
     print("  --version, -v  Show version information\n", .{});
+    print("  --help, -h     Show this help message\n", .{});
 }
 
 pub fn showVersion() void {

--- a/src/cli.zig
+++ b/src/cli.zig
@@ -9,6 +9,7 @@ pub const CliOptions = struct {
     discover_mode: bool,
     verbose: bool,
     show_version: bool,
+    upgrade_mode: bool,
     log_file: ?[]const u8,
     environment: ?[]const u8,
     files: []const []const u8,
@@ -32,6 +33,21 @@ pub const CliOptions = struct {
                 .discover_mode = false,
                 .verbose = false,
                 .show_version = true,
+                .upgrade_mode = false,
+                .log_file = null,
+                .environment = null,
+                .files = &[_][]const u8{},
+                .allocator = null,
+            };
+        }
+
+        // Check for upgrade flag
+        if (containsFlag(args, "--upgrade")) {
+            return CliOptions{
+                .discover_mode = false,
+                .verbose = false,
+                .show_version = false,
+                .upgrade_mode = true,
                 .log_file = null,
                 .environment = null,
                 .files = &[_][]const u8{},
@@ -59,6 +75,7 @@ pub const CliOptions = struct {
                 .discover_mode = true,
                 .verbose = verbose,
                 .show_version = false,
+                .upgrade_mode = false,
                 .log_file = log_file,
                 .environment = environment,
                 .files = &[_][]const u8{},
@@ -78,6 +95,7 @@ pub const CliOptions = struct {
             if (std.mem.eql(u8, arg, "--discover") or
                 std.mem.eql(u8, arg, "--verbose") or
                 std.mem.eql(u8, arg, "--version") or
+                std.mem.eql(u8, arg, "--upgrade") or
                 std.mem.eql(u8, arg, "--help") or
                 std.mem.eql(u8, arg, "-v") or
                 std.mem.eql(u8, arg, "-h"))
@@ -112,6 +130,7 @@ pub const CliOptions = struct {
             .discover_mode = discover_mode,
             .verbose = verbose,
             .show_version = false,
+            .upgrade_mode = false,
             .log_file = log_file,
             .environment = environment,
             .files = files_owned,
@@ -162,6 +181,7 @@ pub fn showUsage() void {
     print("  httprunner <http-file> [http-file2] [...] [--verbose] [--log [filename]] [--env <environment>]\n", .{});
     print("  httprunner [--verbose] [--log [filename]] [--env <environment>] --discover\n", .{});
     print("  httprunner --version | -v\n", .{});
+    print("  httprunner --upgrade\n", .{});
     print("  httprunner --help | -h\n", .{});
     print("\n{s}Arguments:{s}\n", .{ colors.BLUE, colors.RESET });
     print("  <http-file>    One or more .http files to process\n", .{});
@@ -170,6 +190,7 @@ pub fn showUsage() void {
     print("  --log [file]   Log output to a file (defaults to 'log' if no filename is specified)\n", .{});
     print("  --env <env>    Specify environment name to load variables from http-client.env.json\n", .{});
     print("  --version, -v  Show version information\n", .{});
+    print("  --upgrade      Update httprunner to the latest version\n", .{});
     print("  --help, -h     Show this help message\n", .{});
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,6 +5,7 @@ const cli = @import("cli.zig");
 const colors = @import("colors.zig");
 const discovery = @import("discovery.zig");
 const processor = @import("processor.zig");
+const upgrade = @import("upgrade.zig");
 
 pub fn main() !void {
     var gpa = std.heap.GeneralPurposeAllocator(.{}){};
@@ -22,9 +23,13 @@ pub fn main() !void {
         }
     };
     defer options.deinit();
-
     if (options.show_version) {
         cli.showVersion();
+        return;
+    }
+
+    if (options.upgrade_mode) {
+        try upgrade.runUpgrade();
         return;
     }
 

--- a/src/upgrade.zig
+++ b/src/upgrade.zig
@@ -1,0 +1,48 @@
+const std = @import("std");
+const builtin = @import("builtin");
+const print = std.debug.print;
+
+const colors = @import("colors.zig");
+
+pub fn runUpgrade() !void {
+    print("{s}🚀 Upgrading httprunner to the latest version...{s}\n", .{ colors.BLUE, colors.RESET });
+
+    const command = switch (builtin.os.tag) {
+        .windows => "irm https://christianhelle.com/httprunner/install.ps1 | iex",
+        .linux, .macos => "curl -fsSL https://christianhelle.com/httprunner/install | bash",
+        else => {
+            print("{s}❌ Upgrade is not supported on this platform{s}\n", .{ colors.RED, colors.RESET });
+            return;
+        },
+    };
+
+    const shell_args = switch (builtin.os.tag) {
+        .windows => [_][]const u8{ "powershell.exe", "-Command", command },
+        .linux, .macos => [_][]const u8{ "/bin/bash", "-c", command },
+        else => unreachable,
+    };
+
+    print("{s}📦 Running: {s}{s}\n", .{ colors.YELLOW, command, colors.RESET });
+
+    var child = std.process.Child.init(&shell_args, std.heap.page_allocator);
+    child.stdout_behavior = .Inherit;
+    child.stderr_behavior = .Inherit;
+
+    const result = child.spawnAndWait() catch |err| {
+        print("{s}❌ Failed to run upgrade command: {any}{s}\n", .{ colors.RED, err, colors.RESET });
+        return;
+    };
+
+    switch (result) {
+        .Exited => |code| {
+            if (code == 0) {
+                print("{s}✅ Upgrade completed successfully!{s}\n", .{ colors.GREEN, colors.RESET });
+            } else {
+                print("{s}❌ Upgrade failed with exit code: {d}{s}\n", .{ colors.RED, code, colors.RESET });
+            }
+        },
+        else => {
+            print("{s}❌ Upgrade process was terminated unexpectedly{s}\n", .{ colors.RED, colors.RESET });
+        },
+    }
+}


### PR DESCRIPTION
Add support for `--upgrade` and `--help` CLI arguments, along with detailed upgrade instructions in the README. Ensure the upgrade process checks for installation via Snap and executes the appropriate command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a one-step upgrade command (`--upgrade`) that automatically updates the tool based on your operating system.
  - Added clear upgrade instructions and options to the documentation, including both quick and manual upgrade methods.

- **Documentation**
  - Expanded the README with detailed upgrade instructions and troubleshooting tips for all supported platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->