### PR TITLE
Fix git commit showing 'unknown' in GitHub Actions builds

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -23,6 +23,9 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
+    - name: Fetch tags
+      run: git fetch --tags --force
+
     - name: Setup Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -23,6 +23,9 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
+    - name: Fetch tags
+      run: git fetch --tags --force
+
     - name: Setup Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -23,6 +23,9 @@ jobs:
         fetch-depth: 0
         fetch-tags: true
 
+    - name: Fetch tags
+      run: git fetch --tags --force
+
     - name: Setup Rust
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,9 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
+      - name: Fetch tags
+        run: git fetch --tags --force
+
       - name: Update Version
         shell: pwsh
         run: |
@@ -253,6 +256,9 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+
+      - name: Fetch tags
+        run: git fetch --tags --force
 
       - name: Update Version
         shell: pwsh


### PR DESCRIPTION
Fixes the issue where git commit information shows 'unknown' in GitHub Actions builds.

## Problem
GitHub Actions workflows were showing 'unknown' for git commit information in build artifacts and version output.

## Root Cause
The checkout@v5 action with etch-tags: true doesn't always make tags immediately available to subsequent git commands during the build process, especially in the release workflow where tags are created just before the build.

## Solution
Added an explicit git fetch --tags --force step after checkout in all workflows to ensure tags are properly fetched and available to the build process.

## Changes
- Added 'Fetch tags' step to build-linux.yml
- Added 'Fetch tags' step to build-macos.yml
- Added 'Fetch tags' step to build-windows.yml
- Added 'Fetch tags' step to release.yml (2 places: build job and publish-crates job)

## Impact
- Build artifacts will now correctly show git commit hash instead of 'unknown'
- Version information (httprunner --version) will display accurate git metadata
- Applies to all platforms: Linux, macOS, and Windows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build and release workflows with improved tag management during continuous integration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->