### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -9,7 +9,7 @@ pub fn evaluate_assertions(assertions: &[Assertion], result: &HttpResult) -> Vec
 
 fn evaluate_assertion(assertion: &Assertion, result: &HttpResult) -> AssertionResult {
     match assertion.assertion_type {
-        AssertionType::ResponseStatus => {
+        AssertionType::Status => {
             let expected_status = match assertion.expected_value.parse::<u16>() {
                 Ok(status) => status,
                 Err(_) => {
@@ -38,7 +38,7 @@ fn evaluate_assertion(assertion: &Assertion, result: &HttpResult) -> AssertionRe
             }
         }
 
-        AssertionType::ResponseBody => {
+        AssertionType::Body => {
             if let Some(ref body) = result.response_body {
                 let passed = body.contains(&assertion.expected_value);
                 AssertionResult {
@@ -64,7 +64,7 @@ fn evaluate_assertion(assertion: &Assertion, result: &HttpResult) -> AssertionRe
             }
         }
 
-        AssertionType::ResponseHeaders => {
+        AssertionType::Headers => {
             if let Some(ref headers) = result.response_headers {
                 let colon_pos = assertion.expected_value.find(':');
                 if colon_pos.is_none() {
@@ -84,11 +84,11 @@ fn evaluate_assertion(assertion: &Assertion, result: &HttpResult) -> AssertionRe
 
                 let mut found = false;
                 for (name, value) in headers {
-                    if name.eq_ignore_ascii_case(expected_name) {
-                        if value.contains(expected_value) {
-                            found = true;
-                            break;
-                        }
+                    if name.eq_ignore_ascii_case(expected_name)
+                        && value.contains(expected_value)
+                    {
+                        found = true;
+                        break;
                     }
                 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -64,31 +64,31 @@ pub fn parse_http_file(
         }
 
         // Parse assertions
-        if trimmed.starts_with("EXPECTED_RESPONSE_STATUS ") {
+        if let Some(stripped) = trimmed.strip_prefix("EXPECTED_RESPONSE_STATUS ") {
             if let Some(ref mut req) = current_request {
-                let status_str = trimmed[25..].trim();
+                let status_str = stripped.trim();
                 req.assertions.push(Assertion {
-                    assertion_type: AssertionType::ResponseStatus,
+                    assertion_type: AssertionType::Status,
                     expected_value: status_str.to_string(),
                 });
             }
             continue;
-        } else if trimmed.starts_with("EXPECTED_RESPONSE_BODY ") {
+        } else if let Some(stripped) = trimmed.strip_prefix("EXPECTED_RESPONSE_BODY ") {
             if let Some(ref mut req) = current_request {
-                let mut body_value = trimmed[23..].trim();
+                let mut body_value = stripped.trim();
                 if body_value.starts_with('"') && body_value.ends_with('"') && body_value.len() >= 2
                 {
                     body_value = &body_value[1..body_value.len() - 1];
                 }
                 req.assertions.push(Assertion {
-                    assertion_type: AssertionType::ResponseBody,
+                    assertion_type: AssertionType::Body,
                     expected_value: body_value.to_string(),
                 });
             }
             continue;
-        } else if trimmed.starts_with("EXPECTED_RESPONSE_HEADERS ") {
+        } else if let Some(stripped) = trimmed.strip_prefix("EXPECTED_RESPONSE_HEADERS ") {
             if let Some(ref mut req) = current_request {
-                let mut headers_value = trimmed[26..].trim();
+                let mut headers_value = stripped.trim();
                 if headers_value.starts_with('"')
                     && headers_value.ends_with('"')
                     && headers_value.len() >= 2
@@ -96,7 +96,7 @@ pub fn parse_http_file(
                     headers_value = &headers_value[1..headers_value.len() - 1];
                 }
                 req.assertions.push(Assertion {
-                    assertion_type: AssertionType::ResponseHeaders,
+                    assertion_type: AssertionType::Headers,
                     expected_value: headers_value.to_string(),
                 });
             }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -165,7 +165,7 @@ pub fn process_http_files(
             });
 
             if verbose {
-                if let Some(ref ctx) = request_contexts.last() {
+                if let Some(ctx) = request_contexts.last() {
                     if let Some(ref result) = ctx.result {
                         log.writeln(&format!("\n{} Response Details:", colors::blue("📥")));
                         log.writeln(&format!("Status: {}", result.status_code));
@@ -187,15 +187,15 @@ pub fn process_http_files(
             }
 
             if !processed_request.assertions.is_empty() {
-                if let Some(ref ctx) = request_contexts.last() {
+                if let Some(ctx) = request_contexts.last() {
                     if let Some(ref result) = ctx.result {
                         log.writeln(&format!("\n{} Assertion Results:", colors::blue("🔍")));
                         for assertion_result in &result.assertion_results {
                             let assertion_type_str = match assertion_result.assertion.assertion_type
                             {
-                                AssertionType::ResponseStatus => "Status Code",
-                                AssertionType::ResponseBody => "Response Body",
-                                AssertionType::ResponseHeaders => "Response Headers",
+                                AssertionType::Status => "Status Code",
+                                AssertionType::Body => "Response Body",
+                                AssertionType::Headers => "Response Headers",
                             };
 
                             if assertion_result.passed {

--- a/src/types.rs
+++ b/src/types.rs
@@ -54,9 +54,9 @@ pub struct Assertion {
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AssertionType {
-    ResponseStatus,
-    ResponseBody,
-    ResponseHeaders,
+    Status,
+    Body,
+    Headers,
 }
 
 #[derive(Debug)]

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -13,7 +13,7 @@ pub fn run_upgrade() -> Result<()> {
     println!("{} Running: {}", colors::yellow("📦"), command);
 
     let output = Command::new("powershell.exe")
-        .args(&["-Command", command])
+        .args(["-Command", command])
         .output()?;
 
     if output.status.success() {


### PR DESCRIPTION
This pull request refactors the naming of assertion types throughout the codebase for clarity and consistency. The changes replace the verbose `ResponseStatus`, `ResponseBody`, and `ResponseHeaders` with the shorter `Status`, `Body`, and `Headers` variants, and update all relevant parsing, evaluation, and reporting logic accordingly. Additionally, there are minor improvements to code style and argument handling.

Assertion type renaming and consistency:

* Renamed `AssertionType::ResponseStatus`, `AssertionType::ResponseBody`, and `AssertionType::ResponseHeaders` to `AssertionType::Status`, `AssertionType::Body`, and `AssertionType::Headers` respectively in the `AssertionType` enum and updated all usages in `src/types.rs`, `src/assertions.rs`, `src/parser.rs`, and `src/processor.rs` to match. [[1]](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0L57-R59) [[2]](diffhunk://#diff-bfd564c9d58213390035a460951d6263ec4914a9d6dcd3bf1df207c2f1b534c8L12-R12) [[3]](diffhunk://#diff-bfd564c9d58213390035a460951d6263ec4914a9d6dcd3bf1df207c2f1b534c8L41-R41) [[4]](diffhunk://#diff-bfd564c9d58213390035a460951d6263ec4914a9d6dcd3bf1df207c2f1b534c8L67-R67) [[5]](diffhunk://#diff-4a04259da480a6b794a2e947e4cc03eff4d1aa9330836f5b91cac68c5398193fL67-R99) [[6]](diffhunk://#diff-15aeac99995bb0d1d4beb8c747f43517b279f82482f46a33b5461506d866869aL190-R198)

* Updated the parsing logic in `parse_http_file` to use `strip_prefix` for assertion lines and to match the new assertion type names, improving readability and maintainability.

* Simplified assertion evaluation logic in `evaluate_assertion` for headers by combining conditions for name and value matches.

Minor improvements:

* Simplified argument passing to the `Command` in `run_upgrade` by removing an unnecessary reference to a slice.

* Removed unnecessary `ref` in pattern matching for request contexts in `process_http_files` for cleaner code. [[1]](diffhunk://#diff-15aeac99995bb0d1d4beb8c747f43517b279f82482f46a33b5461506d866869aL168-R168) [[2]](diffhunk://#diff-15aeac99995bb0d1d4beb8c747f43517b279f82482f46a33b5461506d866869aL190-R198)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined assertion type naming for improved code clarity.
  * Enhanced parsing robustness with safer string extraction patterns.
  * Optimized platform-specific upgrade flow on Windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->