### PR TITLE
Simplify snapcraft.yaml configuration

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -17,27 +17,11 @@ grade: stable
 confinement: strict
 license: MIT
 
-architectures:
-  - build-on: amd64
-  - build-on: arm64
-  - build-on: armhf
-
 apps:
   httprunner:
     command: bin/httprunner
-    plugs:
-      - network
-      - home
 
 parts:
   httprunner:
     plugin: rust
     source: .
-    rust-channel: stable
-    build-packages:
-      - libssl-dev
-      - pkg-config
-      - git
-    stage-packages:
-      - libssl3
-      - ca-certificates


### PR DESCRIPTION
This pull request simplifies the `snapcraft.yaml` configuration by removing architecture-specific build instructions, extra plugs, and package dependencies. The changes streamline the build process and reduce the configuration's complexity.

Configuration cleanup:

* Removed the `architectures` section, so the snap will use default architecture settings instead of explicitly specifying `amd64`, `arm64`, and `armhf`.
* Removed the `plugs` for `network` and `home` from the `httprunner` app definition, which may restrict the snap's access to network and home directory features.

Dependency and build process simplification:

* Removed the `rust-channel`, `build-packages`, and `stage-packages` from the `httprunner` part, which eliminates explicit dependencies on Rust channel, SSL libraries, and certificate packages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration by removing multi-architecture constraints and unnecessary dependencies from the package definition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->