### PR TITLE
Show same output when using -V and --version arguments

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -13,7 +13,7 @@ const LONG_VERSION: &str = concat!(
 #[derive(Parser)]
 #[command(name = "httprunner")]
 #[command(about = "HTTP File Runner - Execute HTTP requests from .http files", long_about = None)]
-#[command(version = env!("VERSION"))]
+#[command(version = LONG_VERSION)]
 #[command(long_version = LONG_VERSION)]
 pub struct Cli {
     /// One or more .http files to process


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Updated version information output to include additional build details (Git tag, commit, and build date) alongside the version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->