### PR TITLE
Fix GUI app on Ubuntu

### DIFF
--- a/src/gui/Cargo.toml
+++ b/src/gui/Cargo.toml
@@ -30,6 +30,8 @@ eframe = { workspace = true, default-features = false, features = [
     "accesskit",
     "default_fonts",
     "glow",
+    "wayland",
+    "x11",
 ] }
 egui = { workspace = true }
 env_logger = { workspace = true }


### PR DESCRIPTION
This pull request updates the dependencies in `src/gui/Cargo.toml` to enable support for additional windowing backends. Specifically, it adds the `wayland` and `x11` features to the `eframe` dependency, which should improve compatibility on Linux systems.

Dependency updates for platform support:

* Added the `wayland` and `x11` features to the `eframe` dependency in `Cargo.toml` to enable support for both major Linux windowing systems.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced platform support for Wayland and X11 in the GUI application, expanding compatibility across Linux desktop environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->