### PR TITLE
Fix --upgrade fails on Linux and MacOS due to captured stdio

### DIFF
--- a/src/cli/src/upgrade/linux.rs
+++ b/src/cli/src/upgrade/linux.rs
@@ -22,15 +22,15 @@ pub fn run_upgrade() -> Result<()> {
         ("/bin/bash", vec!["-c", command])
     };
 
-    let output = Command::new(shell).args(args).output()?;
+    let status = Command::new(shell).args(args).status()?;
 
-    if output.status.success() {
+    if status.success() {
         println!("{} Upgrade completed successfully!", colors::green("✅"));
     } else {
         println!(
             "{} Upgrade failed with exit code: {:?}",
             colors::red("❌"),
-            output.status.code()
+            status.code()
         );
     }
 

--- a/src/cli/src/upgrade/macos.rs
+++ b/src/cli/src/upgrade/macos.rs
@@ -11,15 +11,15 @@ pub fn run_upgrade() -> Result<()> {
     let command = "curl -fsSL https://christianhelle.com/httprunner/install | bash";
     println!("{} Running: {}", colors::yellow("📦"), command);
 
-    let output = Command::new("/bin/bash").args(["-c", command]).output()?;
+    let status = Command::new("/bin/bash").args(["-c", command]).status()?;
 
-    if output.status.success() {
+    if status.success() {
         println!("{} Upgrade completed successfully!", colors::green("✅"));
     } else {
         println!(
             "{} Upgrade failed with exit code: {:?}",
             colors::red("❌"),
-            output.status.code()
+            status.code()
         );
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized upgrade process for Linux and macOS platforms with improved command execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->