### PR TITLE
Add vertical scrolling support in the Environment Editor for the TUI app

### DIFF
--- a/src/tui/src/environment_editor.rs
+++ b/src/tui/src/environment_editor.rs
@@ -214,9 +214,10 @@ impl EnvironmentEditor {
     /// Compute the line index of the currently selected item within the rendered content.
     /// This must mirror the line layout in render_environment_editor in ui.rs.
     fn selected_item_line(&self) -> usize {
-        // Line 0: help text
-        // Line 1: blank
-        let mut line = 2;
+        // Line 0: help text line 1
+        // Line 1: help text line 2
+        // Line 2: blank
+        let mut line = 3;
 
         if self.env_names.is_empty() {
             return line;

--- a/src/tui/src/ui.rs
+++ b/src/tui/src/ui.rs
@@ -597,12 +597,18 @@ fn render_environment_editor(f: &mut Frame, area: Rect, app: &App) {
 
     // Help text
     lines.push(Line::from(vec![
+        Span::styled("↑/↓", Style::default().fg(Color::Yellow)),
+        Span::raw(" Nav | "),
+        Span::styled("PgUp/PgDn", Style::default().fg(Color::Yellow)),
+        Span::raw(" Scroll | "),
         Span::styled("←/→", Style::default().fg(Color::Yellow)),
         Span::raw(" Switch | "),
         Span::styled("n", Style::default().fg(Color::Yellow)),
         Span::raw(" New Env | "),
         Span::styled("a", Style::default().fg(Color::Yellow)),
-        Span::raw(" Add Var | "),
+        Span::raw(" Add Var"),
+    ]));
+    lines.push(Line::from(vec![
         Span::styled("e/Enter", Style::default().fg(Color::Yellow)),
         Span::raw(" Edit | "),
         Span::styled("r", Style::default().fg(Color::Yellow)),


### PR DESCRIPTION
- **Add scroll_offset and auto-scroll to environment editor**
- **Apply vertical scroll offset in environment editor rendering**
- **Add navigation and scroll hints to environment editor help text**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added scrolling support to the environment editor with PageUp, PageDown, and Home navigation commands
  * Updated help text to display navigation and scroll instructions
  * Focused items now automatically remain visible when navigating

<!-- end of auto-generated comment: release notes by coderabbit.ai -->