### PR TITLE
Hide support key when telemetry collection is disabled

### DIFF
--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -78,7 +78,7 @@ fn run(cli_args: &cli::Cli) -> Result<()> {
     let results = process_http_files(cli_args, files)?;
     generate_report(cli_args, &results)?;
     export_results(cli_args, &results)?;
-    show_support_key();
+    show_support_key(cli_args);
     if !cli_args.no_banner {
         cli::show_donation_banner();
     }
@@ -171,7 +171,10 @@ fn export_results(cli_args: &cli::Cli, results: &ProcessorResults) -> Result<()>
     Ok(())
 }
 
-fn show_support_key() {
+fn show_support_key(cli_args: &cli::Cli) {
+    if cli_args.no_telemetry {
+        return;
+    }
     match logging::get_support_key() {
         Ok(support_key) => {
             println!(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Support key display now respects the no-telemetry flag, preventing telemetry-related operations when disabled by the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->