### PR TITLE
Use enumerate instead of manual loop counter in split_lines_fast

### DIFF
--- a/src/core/src/parser/pest_parser.rs
+++ b/src/core/src/parser/pest_parser.rs
@@ -4,9 +4,9 @@ use super::pest_parse_tree::{
     PestHeaderLine, PestHttpFile, PestLine, PestLineKind, PestRequestLine, PestScriptBlock,
     PestTimeoutLiteral, PestVariableLine,
 };
-use anyhow::{anyhow, bail, Context, Result};
-use pest::iterators::{Pair, Pairs};
+use anyhow::{Context, Result, anyhow, bail};
 use pest::Parser;
+use pest::iterators::{Pair, Pairs};
 use pest_derive::Parser;
 
 #[derive(Parser)]

--- a/src/core/src/parser/pest_parser.rs
+++ b/src/core/src/parser/pest_parser.rs
@@ -4,9 +4,9 @@ use super::pest_parse_tree::{
     PestHeaderLine, PestHttpFile, PestLine, PestLineKind, PestRequestLine, PestScriptBlock,
     PestTimeoutLiteral, PestVariableLine,
 };
-use anyhow::{Context, Result, anyhow, bail};
-use pest::Parser;
+use anyhow::{anyhow, bail, Context, Result};
 use pest::iterators::{Pair, Pairs};
+use pest::Parser;
 use pest_derive::Parser;
 
 #[derive(Parser)]
@@ -65,19 +65,17 @@ fn split_lines_fast(content: &str) -> PestRawHttpFile<'_> {
     // terminal '\n', which matches the behaviour of `str::lines()` and avoids
     // adding a spurious blank line at the end of the file.
     let mut lines = Vec::new();
-    let mut line_number = 1usize;
 
-    for raw in content.split_terminator('\n') {
+    for (line_number, raw) in content.split_terminator('\n').enumerate() {
         // Strip the '\r' so CRLF files are handled transparently.
         let raw = raw.strip_suffix('\r').unwrap_or(raw);
         lines.push(PestRawLine {
-            line_number,
+            line_number: line_number + 1,
             raw,
             // All lines are Regular; the semantic assembler drives
             // IgnoredScriptBlock handling via its `in_intellij_script` flag.
             kind: PestRawLineKind::Regular,
         });
-        line_number += 1;
     }
 
     PestRawHttpFile { lines }

--- a/src/tui/src/app.rs
+++ b/src/tui/src/app.rs
@@ -130,23 +130,26 @@ impl App {
                 return Ok(());
             }
             (KeyCode::Char(']'), KeyModifiers::NONE)
-                if self.focused_pane != FocusedPane::EnvironmentEditor => {
-                    self.increase_delay();
-                    return Ok(());
-                }
+                if self.focused_pane != FocusedPane::EnvironmentEditor =>
+            {
+                self.increase_delay();
+                return Ok(());
+            }
             (KeyCode::Char('['), KeyModifiers::NONE)
-                if self.focused_pane != FocusedPane::EnvironmentEditor => {
-                    self.decrease_delay();
-                    return Ok(());
-                }
+                if self.focused_pane != FocusedPane::EnvironmentEditor =>
+            {
+                self.decrease_delay();
+                return Ok(());
+            }
             (KeyCode::F(5), _)
             | (KeyCode::Char('r'), KeyModifiers::CONTROL)
             | (KeyCode::Char('r'), KeyModifiers::NONE)
             | (KeyCode::Char('R'), KeyModifiers::SHIFT)
-                if self.focused_pane != FocusedPane::EnvironmentEditor => {
-                    self.run_all_requests();
-                    return Ok(());
-                }
+                if self.focused_pane != FocusedPane::EnvironmentEditor =>
+            {
+                self.run_all_requests();
+                return Ok(());
+            }
             _ => {}
         }
 

--- a/src/tui/src/app.rs
+++ b/src/tui/src/app.rs
@@ -129,27 +129,24 @@ impl App {
                 self.toggle_telemetry();
                 return Ok(());
             }
-            (KeyCode::Char(']'), KeyModifiers::NONE) => {
-                if self.focused_pane != FocusedPane::EnvironmentEditor {
+            (KeyCode::Char(']'), KeyModifiers::NONE)
+                if self.focused_pane != FocusedPane::EnvironmentEditor => {
                     self.increase_delay();
                     return Ok(());
                 }
-            }
-            (KeyCode::Char('['), KeyModifiers::NONE) => {
-                if self.focused_pane != FocusedPane::EnvironmentEditor {
+            (KeyCode::Char('['), KeyModifiers::NONE)
+                if self.focused_pane != FocusedPane::EnvironmentEditor => {
                     self.decrease_delay();
                     return Ok(());
                 }
-            }
             (KeyCode::F(5), _)
             | (KeyCode::Char('r'), KeyModifiers::CONTROL)
             | (KeyCode::Char('r'), KeyModifiers::NONE)
-            | (KeyCode::Char('R'), KeyModifiers::SHIFT) => {
-                if self.focused_pane != FocusedPane::EnvironmentEditor {
+            | (KeyCode::Char('R'), KeyModifiers::SHIFT)
+                if self.focused_pane != FocusedPane::EnvironmentEditor => {
                     self.run_all_requests();
                     return Ok(());
                 }
-            }
             _ => {}
         }
 

--- a/src/tui/src/environment_editor.rs
+++ b/src/tui/src/environment_editor.rs
@@ -377,21 +377,19 @@ impl EnvironmentEditor {
                 self.scroll_offset = 0;
             }
             // Add new environment
-            (KeyCode::Char('n'), KeyModifiers::NONE) => {
-                if self.focus == EditorFocus::EnvironmentList {
+            (KeyCode::Char('n'), KeyModifiers::NONE)
+                if self.focus == EditorFocus::EnvironmentList => {
                     self.input_mode = InputMode::NewEnvironment;
                     self.input_buffer.clear();
                     self.focus = EditorFocus::Input;
                 }
-            }
             // Add new variable
-            (KeyCode::Char('a'), KeyModifiers::NONE) => {
-                if self.focus == EditorFocus::VariableList && !self.env_names.is_empty() {
+            (KeyCode::Char('a'), KeyModifiers::NONE)
+                if self.focus == EditorFocus::VariableList && !self.env_names.is_empty() => {
                     self.input_mode = InputMode::NewVariableName;
                     self.input_buffer.clear();
                     self.focus = EditorFocus::Input;
                 }
-            }
             // Edit variable value
             (KeyCode::Enter, _) | (KeyCode::Char('e'), KeyModifiers::NONE) => {
                 if self.focus == EditorFocus::VariableList

--- a/src/tui/src/environment_editor.rs
+++ b/src/tui/src/environment_editor.rs
@@ -378,18 +378,20 @@ impl EnvironmentEditor {
             }
             // Add new environment
             (KeyCode::Char('n'), KeyModifiers::NONE)
-                if self.focus == EditorFocus::EnvironmentList => {
-                    self.input_mode = InputMode::NewEnvironment;
-                    self.input_buffer.clear();
-                    self.focus = EditorFocus::Input;
-                }
+                if self.focus == EditorFocus::EnvironmentList =>
+            {
+                self.input_mode = InputMode::NewEnvironment;
+                self.input_buffer.clear();
+                self.focus = EditorFocus::Input;
+            }
             // Add new variable
             (KeyCode::Char('a'), KeyModifiers::NONE)
-                if self.focus == EditorFocus::VariableList && !self.env_names.is_empty() => {
-                    self.input_mode = InputMode::NewVariableName;
-                    self.input_buffer.clear();
-                    self.focus = EditorFocus::Input;
-                }
+                if self.focus == EditorFocus::VariableList && !self.env_names.is_empty() =>
+            {
+                self.input_mode = InputMode::NewVariableName;
+                self.input_buffer.clear();
+                self.focus = EditorFocus::Input;
+            }
             // Edit variable value
             (KeyCode::Enter, _) | (KeyCode::Char('e'), KeyModifiers::NONE) => {
                 if self.focus == EditorFocus::VariableList

--- a/src/tui/src/file_tree.rs
+++ b/src/tui/src/file_tree.rs
@@ -80,14 +80,14 @@ impl FileTree {
         let files_len = self.files.lock().map(|f| f.len()).unwrap_or(0);
 
         match key.code {
-            KeyCode::Up | KeyCode::Char('k')
-                if self.selected_index > 0 => {
-                    self.selected_index -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if self.selected_index > 0 => {
+                self.selected_index -= 1;
+            }
             KeyCode::Down | KeyCode::Char('j')
-                if self.selected_index < files_len.saturating_sub(1) => {
-                    self.selected_index += 1;
-                }
+                if self.selected_index < files_len.saturating_sub(1) =>
+            {
+                self.selected_index += 1;
+            }
             KeyCode::Home => {
                 self.selected_index = 0;
             }

--- a/src/tui/src/file_tree.rs
+++ b/src/tui/src/file_tree.rs
@@ -80,16 +80,14 @@ impl FileTree {
         let files_len = self.files.lock().map(|f| f.len()).unwrap_or(0);
 
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.selected_index > 0 {
+            KeyCode::Up | KeyCode::Char('k')
+                if self.selected_index > 0 => {
                     self.selected_index -= 1;
                 }
-            }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if self.selected_index < files_len.saturating_sub(1) {
+            KeyCode::Down | KeyCode::Char('j')
+                if self.selected_index < files_len.saturating_sub(1) => {
                     self.selected_index += 1;
                 }
-            }
             KeyCode::Home => {
                 self.selected_index = 0;
             }

--- a/src/tui/src/request_view.rs
+++ b/src/tui/src/request_view.rs
@@ -42,16 +42,14 @@ impl RequestView {
         self.run_request = false;
 
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.selected_index > 0 {
+            KeyCode::Up | KeyCode::Char('k')
+                if self.selected_index > 0 => {
                     self.selected_index -= 1;
                 }
-            }
-            KeyCode::Down | KeyCode::Char('j') => {
-                if self.selected_index < self.requests.len().saturating_sub(1) {
+            KeyCode::Down | KeyCode::Char('j')
+                if self.selected_index < self.requests.len().saturating_sub(1) => {
                     self.selected_index += 1;
                 }
-            }
             KeyCode::Enter => {
                 self.run_request = true;
             }

--- a/src/tui/src/request_view.rs
+++ b/src/tui/src/request_view.rs
@@ -42,14 +42,14 @@ impl RequestView {
         self.run_request = false;
 
         match key.code {
-            KeyCode::Up | KeyCode::Char('k')
-                if self.selected_index > 0 => {
-                    self.selected_index -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if self.selected_index > 0 => {
+                self.selected_index -= 1;
+            }
             KeyCode::Down | KeyCode::Char('j')
-                if self.selected_index < self.requests.len().saturating_sub(1) => {
-                    self.selected_index += 1;
-                }
+                if self.selected_index < self.requests.len().saturating_sub(1) =>
+            {
+                self.selected_index += 1;
+            }
             KeyCode::Enter => {
                 self.run_request = true;
             }

--- a/src/tui/src/results_view.rs
+++ b/src/tui/src/results_view.rs
@@ -106,10 +106,9 @@ impl ResultsView {
 
     pub fn handle_key_event(&mut self, key: KeyEvent) {
         match key.code {
-            KeyCode::Up | KeyCode::Char('k')
-                if self.scroll_offset > 0 => {
-                    self.scroll_offset -= 1;
-                }
+            KeyCode::Up | KeyCode::Char('k') if self.scroll_offset > 0 => {
+                self.scroll_offset -= 1;
+            }
             KeyCode::Down | KeyCode::Char('j') => {
                 self.scroll_offset += 1;
             }

--- a/src/tui/src/results_view.rs
+++ b/src/tui/src/results_view.rs
@@ -106,11 +106,10 @@ impl ResultsView {
 
     pub fn handle_key_event(&mut self, key: KeyEvent) {
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
-                if self.scroll_offset > 0 {
+            KeyCode::Up | KeyCode::Char('k')
+                if self.scroll_offset > 0 => {
                     self.scroll_offset -= 1;
                 }
-            }
             KeyCode::Down | KeyCode::Char('j') => {
                 self.scroll_offset += 1;
             }


### PR DESCRIPTION
## Summary
- Replace manual `line_number` counter with `.enumerate()` in `split_lines_fast`
- Eliminates clippy warning about using a variable as a loop counter
- Reduces code by 2 lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code improvements across HTTP parsing and keyboard event handling for enhanced maintainability and code structure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christianhelle/httprunner/pull/266?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->