### PR TITLE
Publish arm64 linux binary

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -39,7 +39,7 @@ jobs:
         cache: true
 
     - name: Install Linux dependencies for GUI
-      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
+      if: contains(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
         sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -9,10 +9,18 @@ on:
 
 jobs:
   build-linux:
-    name: Build Linux
-    timeout-minutes: 10
-    runs-on: ubuntu-latest
+    name: Build Linux (${{ matrix.target }})
+    timeout-minutes: 15
+    runs-on: ${{ matrix.os }}
     
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
@@ -27,9 +35,11 @@ jobs:
       uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: stable
+        target: ${{ matrix.target }}
         cache: true
 
     - name: Install Linux dependencies for GUI
+      if: matrix.os == 'ubuntu-latest' || matrix.os == 'ubuntu-24.04-arm'
       run: |
         sudo apt-get update
         sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev
@@ -38,19 +48,19 @@ jobs:
       run: cargo clippy -- -D warnings
 
     - name: Build
-      run: cargo build
+      run: cargo build --target ${{ matrix.target }}
 
     - name: Run tests
-      run: cargo test
+      run: cargo test --target ${{ matrix.target }}
 
     - name: Build release
-      run: cargo build --release
+      run: cargo build --release --target ${{ matrix.target }}
 
     - name: Upload Artifacts
       uses: actions/upload-artifact@v7
       with:
-        name: httprunner-linux
+        name: httprunner-linux-${{ matrix.target }}
         path: |
-          target/release/httprunner
-          target/release/httprunner-gui
-          target/release/httprunner-tui
+          target/${{ matrix.target }}/release/httprunner
+          target/${{ matrix.target }}/release/httprunner-gui
+          target/${{ matrix.target }}/release/httprunner-tui

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,10 @@ jobs:
             target: x86_64-pc-windows-msvc
             binary_name: httprunner.exe
             archive_name: httprunner-windows-x86_64.zip
+          - os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            binary_name: httprunner
+            archive_name: httprunner-linux-aarch64.tar.gz
           - os: macos-latest
             target: x86_64-apple-darwin
             binary_name: httprunner
@@ -93,7 +97,7 @@ jobs:
           cache: true
 
       - name: Install Linux dependencies for GUI
-        if: matrix.os == 'ubuntu-latest'
+        if: contains(matrix.os, 'ubuntu')
         run: |
           sudo apt-get update
           sudo apt-get install -y libxcb-render0-dev libxcb-shape0-dev libxcb-xfixes0-dev libxkbcommon-dev libssl-dev

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ irm https://christianhelle.com/httprunner/install.ps1 | iex -InstallDir "C:\Tool
 Download the latest release for your platform from the [GitHub Releases page](https://github.com/christianhelle/httprunner/releases/latest):
 
 - **Linux x86_64:** `httprunner-linux-x86_64.tar.gz`
+- **Linux ARM64:** `httprunner-linux-aarch64.tar.gz`
 - **macOS x86_64:** `httprunner-macos-x86_64.tar.gz`
 - **macOS ARM64:** `httprunner-macos-aarch64.tar.gz`
 - **Windows x86_64:** `httprunner-windows-x86_64.zip`

--- a/docs/install.html
+++ b/docs/install.html
@@ -117,6 +117,7 @@
                         <div class="platform-list">
                             <ul>
                                 <li>🐧 Linux x86_64: <code>httprunner-linux-x86_64.tar.gz</code></li>
+                                <li>🐧 Linux ARM64: <code>httprunner-linux-aarch64.tar.gz</code></li>
                                 <li>🍎 macOS x86_64: <code>httprunner-macos-x86_64.tar.gz</code></li>
                                 <li>🍎 macOS ARM64: <code>httprunner-macos-aarch64.tar.gz</code></li>
                                 <li>🪟 Windows x86_64: <code>httprunner-windows-x86_64.zip</code></li>


### PR DESCRIPTION
This pull request adds support for building and releasing ARM64 (aarch64) Linux binaries for `httprunner`. The changes update the CI workflows to build, test, and package for both x86_64 and ARM64 Linux targets, and update documentation to reflect the new ARM64 release artifact.

**CI/CD workflow enhancements:**

- Added a build matrix to `.github/workflows/build-linux.yml` to build and test both x86_64 and ARM64 (`aarch64-unknown-linux-gnu`) targets on appropriate Ubuntu runners, including updating build, test, and artifact upload steps to use the matrix target and path. [[1]](diffhunk://#diff-bfc3aeacfea5c320a79818465fb6d4b9901e2c1fc26af712702cae54db219bdcL12-R22) [[2]](diffhunk://#diff-bfc3aeacfea5c320a79818465fb6d4b9901e2c1fc26af712702cae54db219bdcR38-R42) [[3]](diffhunk://#diff-bfc3aeacfea5c320a79818465fb6d4b9901e2c1fc26af712702cae54db219bdcL41-R66)
- Updated `.github/workflows/release.yml` to include ARM64 Linux in the release matrix, specifying the target, binary name, and archive name for the new artifact, and generalized the dependency installation step to work for all Ubuntu runners. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R62-R65) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L96-R100)

**Documentation updates:**

- Added references to the new `httprunner-linux-aarch64.tar.gz` artifact in both `README.md` and `docs/install.html` to inform users about the availability of the Linux ARM64 release. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R98) [[2]](diffhunk://#diff-50f15604e57f070b679bd2d8e2ec71c459cefa47930e1fb4ccb81eca49dfd59aR120)

Implements #263 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and releasing on Linux ARM64 architecture.

* **Documentation**
  * Updated installation guides to include Linux ARM64 release artifacts for download.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christianhelle/httprunner/pull/267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->