### PR TITLE
Fix verbose failure details and skip rendering

### DIFF
--- a/.squad/agents/hicks/history.md
+++ b/.squad/agents/hicks/history.md
@@ -13,6 +13,7 @@
 - Rust 1.92+ edition 2024 is not widely documented—creates contributor friction.
 - **Baseline (2026-03-21):** Current branch passes all platform validation checks (format, linting, debug build, test suite, release build). 915 unit tests, 2.74 MB release binary on Windows. No platform blockers before parser changes.
 - **2026-05-29T16:27:00.865+02:00:** Commit hygiene automation now lives in `.github/copilot-instructions.md`, mirrored in `.squad/copilot-instructions.md` and `.squad/templates/copilot-instructions.md`; commit groups used here were core/CLI fail-fast, GUI/TUI fail-fast, and instruction/config updates.
+- **2026-05-29T17:25:53.739+02:00:** Created PR #268 (fail-fast branch → main). Summary: fail-fast mode across CLI, GUI (native+WASM), and TUI; WASM GUI build unblocked; automatic commit-hygiene instruction enforcement. Base branch: main. Verification checklist included for all four execution paths.
 
 ## 2026-03-21: Pest.rs Migration Investigation Complete
 

--- a/src/gui/src/results_view.rs
+++ b/src/gui/src/results_view.rs
@@ -1018,4 +1018,59 @@ mod tests {
         // fail-fast disabled never stops
         assert!(should_continue_after_async(&failed, false));
     }
+
+    #[test]
+    fn failure_result_simple_has_no_optional_fields() {
+        let f = FailureResult::simple(
+            "GET".to_string(),
+            "https://example.com".to_string(),
+            "connection refused".to_string(),
+        );
+        assert_eq!(f.method, "GET");
+        assert_eq!(f.url, "https://example.com");
+        assert_eq!(f.error, "connection refused");
+        assert!(f.status.is_none());
+        assert!(f.duration_ms.is_none());
+        assert!(f.request_body.is_none());
+        assert!(f.response_body.is_none());
+        assert!(f.assertion_results.is_empty());
+    }
+
+    #[test]
+    fn failure_result_full_construction_preserves_all_fields() {
+        let f = FailureResult {
+            method: "POST".to_string(),
+            url: "https://api.example.com/data".to_string(),
+            error: "500 Internal Server Error".to_string(),
+            status: Some(500),
+            duration_ms: Some(42),
+            request_body: Some("{\"key\":\"value\"}".to_string()),
+            response_body: Some("server error detail".to_string()),
+            assertion_results: vec![],
+        };
+        assert_eq!(f.status, Some(500));
+        assert_eq!(f.duration_ms, Some(42));
+        assert_eq!(f.request_body.as_deref(), Some("{\"key\":\"value\"}"));
+        assert_eq!(f.response_body.as_deref(), Some("server error detail"));
+    }
+
+    #[test]
+    fn results_view_fail_fast_defaults_to_false_and_can_be_toggled() {
+        let mut rv = ResultsView::new();
+        assert!(!rv.is_fail_fast());
+        rv.set_fail_fast(true);
+        assert!(rv.is_fail_fast());
+        rv.set_fail_fast(false);
+        assert!(!rv.is_fail_fast());
+    }
+
+    #[test]
+    fn results_view_compact_mode_defaults_to_true_and_can_be_toggled() {
+        let mut rv = ResultsView::new();
+        assert!(rv.is_compact_mode());
+        rv.set_compact_mode(false);
+        assert!(!rv.is_compact_mode());
+        rv.set_compact_mode(true);
+        assert!(rv.is_compact_mode());
+    }
 }

--- a/src/gui/src/results_view.rs
+++ b/src/gui/src/results_view.rs
@@ -30,6 +30,36 @@ struct VerboseSuccessParams<'a> {
     assertion_results: &'a [AssertionResult],
 }
 
+/// Detail captured for a failed result. For failures that originate from an
+/// executed request, the optional fields preserve the full HTTP detail so the
+/// verbose view (e.g. after a fail-fast halt) can render status, bodies and
+/// assertion results. Non-execution failures (parse/read/panic/index/skip)
+/// only populate `method`, `url` and `error`.
+#[derive(Clone, Serialize, Deserialize, Debug, Default)]
+pub struct FailureResult {
+    pub method: String,
+    pub url: String,
+    pub error: String,
+    pub status: Option<u16>,
+    pub duration_ms: Option<u64>,
+    pub request_body: Option<String>,
+    pub response_body: Option<String>,
+    pub assertion_results: Vec<AssertionResult>,
+}
+
+impl FailureResult {
+    /// Build a failure that only carries an error message, for failures with no
+    /// HTTP response detail to preserve.
+    pub fn simple(method: String, url: String, error: String) -> Self {
+        Self {
+            method,
+            url,
+            error,
+            ..Default::default()
+        }
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub enum ExecutionResult {
     Success {
@@ -41,11 +71,7 @@ pub enum ExecutionResult {
         response_body: String,
         assertion_results: Vec<AssertionResult>,
     },
-    Failure {
-        method: String,
-        url: String,
-        error: String,
-    },
+    Failure(FailureResult),
     Running {
         message: String,
     },
@@ -169,11 +195,13 @@ impl ResultsView {
                                     RequestProcessingResult::Skipped { request, reason } => {
                                         skipped_count += 1;
                                         if let Ok(mut r) = results.lock() {
-                                            r.push(ExecutionResult::Failure {
-                                                method: format!("⏭️ {}", request.method),
-                                                url: request.url,
-                                                error: format!("Skipped: {}", reason),
-                                            });
+                                            r.push(ExecutionResult::Failure(
+                                                FailureResult::simple(
+                                                    format!("⏭️ {}", request.method),
+                                                    request.url,
+                                                    format!("Skipped: {}", reason),
+                                                ),
+                                            ));
                                         }
                                     }
                                     RequestProcessingResult::Executed { request, result } => {
@@ -196,24 +224,31 @@ impl ResultsView {
                                         } else {
                                             failed_count += 1;
                                             if let Ok(mut r) = results.lock() {
-                                                r.push(ExecutionResult::Failure {
+                                                r.push(ExecutionResult::Failure(FailureResult {
                                                     method: request.method,
                                                     url: request.url,
                                                     error: result.error_message.unwrap_or_else(
                                                         || "Unknown error".to_string(),
                                                     ),
-                                                });
+                                                    status: Some(result.status_code),
+                                                    duration_ms: Some(result.duration_ms),
+                                                    request_body,
+                                                    response_body: result.response_body,
+                                                    assertion_results: result.assertion_results,
+                                                }));
                                             }
                                         }
                                     }
                                     RequestProcessingResult::Failed { request, error } => {
                                         failed_count += 1;
                                         if let Ok(mut r) = results.lock() {
-                                            r.push(ExecutionResult::Failure {
-                                                method: request.method,
-                                                url: request.url,
-                                                error,
-                                            });
+                                            r.push(ExecutionResult::Failure(
+                                                FailureResult::simple(
+                                                    request.method,
+                                                    request.url,
+                                                    error,
+                                                ),
+                                            ));
                                         }
                                     }
                                 }
@@ -238,11 +273,11 @@ impl ResultsView {
 
                         if let Ok(mut r) = results.lock() {
                             r.clear();
-                            r.push(ExecutionResult::Failure {
-                                method: "PARSE".to_string(),
-                                url: path.display().to_string(),
-                                error: format!("Failed to parse file: {}", e),
-                            });
+                            r.push(ExecutionResult::Failure(FailureResult::simple(
+                                "PARSE".to_string(),
+                                path.display().to_string(),
+                                format!("Failed to parse file: {}", e),
+                            )));
                         }
                     } else {
                         // Track execution completion
@@ -260,11 +295,11 @@ impl ResultsView {
                     }
                 } else if let Ok(mut r) = results.lock() {
                     r.clear();
-                    r.push(ExecutionResult::Failure {
-                        method: "READ".to_string(),
-                        url: path.display().to_string(),
-                        error: "Failed to convert path to string".to_string(),
-                    });
+                    r.push(ExecutionResult::Failure(FailureResult::simple(
+                        "READ".to_string(),
+                        path.display().to_string(),
+                        "Failed to convert path to string".to_string(),
+                    )));
                 }
             }));
 
@@ -273,11 +308,11 @@ impl ResultsView {
                 telemetry::track_error_message(&format!("Execution panic: {}", panic_message));
                 if let Ok(mut r) = results.lock() {
                     r.clear();
-                    r.push(ExecutionResult::Failure {
-                        method: "PANIC".to_string(),
-                        url: path.display().to_string(),
-                        error: format!("Background execution panicked: {}", panic_message),
-                    });
+                    r.push(ExecutionResult::Failure(FailureResult::simple(
+                        "PANIC".to_string(),
+                        path.display().to_string(),
+                        format!("Background execution panicked: {}", panic_message),
+                    )));
                 }
             }
 
@@ -334,11 +369,11 @@ impl ResultsView {
                                         !should_continue_after(&process_result, true);
                                     target_result = Some(match process_result {
                                         RequestProcessingResult::Skipped { request, reason } => {
-                                            ExecutionResult::Failure {
-                                                method: format!("⏭️ {}", request.method),
-                                                url: request.url,
-                                                error: format!("Skipped: {}", reason),
-                                            }
+                                            ExecutionResult::Failure(FailureResult::simple(
+                                                format!("⏭️ {}", request.method),
+                                                request.url,
+                                                format!("Skipped: {}", reason),
+                                            ))
                                         }
                                         RequestProcessingResult::Executed { request, result } => {
                                             let request_body = request.body.clone();
@@ -355,21 +390,26 @@ impl ResultsView {
                                                     assertion_results: result.assertion_results,
                                                 }
                                             } else {
-                                                ExecutionResult::Failure {
+                                                ExecutionResult::Failure(FailureResult {
                                                     method: request.method,
                                                     url: request.url,
                                                     error: result.error_message.unwrap_or_else(
                                                         || "Unknown error".to_string(),
                                                     ),
-                                                }
+                                                    status: Some(result.status_code),
+                                                    duration_ms: Some(result.duration_ms),
+                                                    request_body,
+                                                    response_body: result.response_body,
+                                                    assertion_results: result.assertion_results,
+                                                })
                                             }
                                         }
                                         RequestProcessingResult::Failed { request, error } => {
-                                            ExecutionResult::Failure {
-                                                method: request.method,
-                                                url: request.url,
+                                            ExecutionResult::Failure(FailureResult::simple(
+                                                request.method,
+                                                request.url,
                                                 error,
-                                            }
+                                            ))
                                         }
                                     });
                                     // Fail-fast: surface the failing request in verbose.
@@ -393,11 +433,11 @@ impl ResultsView {
                     if let Err(e) = result {
                         if let Ok(mut r) = results.lock() {
                             r.clear();
-                            r.push(ExecutionResult::Failure {
-                                method: "PARSE".to_string(),
-                                url: path.display().to_string(),
-                                error: format!("Failed to parse file: {}", e),
-                            });
+                            r.push(ExecutionResult::Failure(FailureResult::simple(
+                                "PARSE".to_string(),
+                                path.display().to_string(),
+                                format!("Failed to parse file: {}", e),
+                            )));
                         }
                     } else if let Some(result) = target_result {
                         if let Ok(mut r) = results.lock() {
@@ -406,19 +446,19 @@ impl ResultsView {
                         }
                     } else if let Ok(mut r) = results.lock() {
                         r.clear();
-                        r.push(ExecutionResult::Failure {
-                            method: "INDEX".to_string(),
-                            url: path.display().to_string(),
-                            error: format!("Request index {} not found", index),
-                        });
+                        r.push(ExecutionResult::Failure(FailureResult::simple(
+                            "INDEX".to_string(),
+                            path.display().to_string(),
+                            format!("Request index {} not found", index),
+                        )));
                     }
                 } else if let Ok(mut r) = results.lock() {
                     r.clear();
-                    r.push(ExecutionResult::Failure {
-                        method: "PATH".to_string(),
-                        url: path.display().to_string(),
-                        error: "Failed to convert path to string".to_string(),
-                    });
+                    r.push(ExecutionResult::Failure(FailureResult::simple(
+                        "PATH".to_string(),
+                        path.display().to_string(),
+                        "Failed to convert path to string".to_string(),
+                    )));
                 }
             }));
 
@@ -427,11 +467,11 @@ impl ResultsView {
                 telemetry::track_error_message(&format!("Execution panic: {}", panic_message));
                 if let Ok(mut r) = results.lock() {
                     r.clear();
-                    r.push(ExecutionResult::Failure {
-                        method: "PANIC".to_string(),
-                        url: path.display().to_string(),
-                        error: format!("Background execution panicked: {}", panic_message),
-                    });
+                    r.push(ExecutionResult::Failure(FailureResult::simple(
+                        "PANIC".to_string(),
+                        path.display().to_string(),
+                        format!("Background execution panicked: {}", panic_message),
+                    )));
                 }
             }
 
@@ -530,11 +570,16 @@ impl ResultsView {
                             );
                         }
                     }
-                    ExecutionResult::Failure { method, url, error } => {
+                    ExecutionResult::Failure(failure) => {
                         if self.compact_mode {
-                            self.show_compact_failure(ui, method, url, error);
+                            self.show_compact_failure(
+                                ui,
+                                &failure.method,
+                                &failure.url,
+                                &failure.error,
+                            );
                         } else {
-                            self.show_verbose_failure(ui, method, url, error);
+                            self.show_verbose_failure(ui, result_idx, failure);
                         }
                     }
                     ExecutionResult::Running { message } => {
@@ -716,11 +761,101 @@ impl ResultsView {
         ui.separator();
     }
 
-    fn show_verbose_failure(&self, ui: &mut egui::Ui, method: &str, url: &str, error: &str) {
+    fn show_verbose_failure(&self, ui: &mut egui::Ui, result_idx: usize, failure: &FailureResult) {
         ui.colored_label(egui::Color32::from_rgb(200, 0, 0), "❌ FAILED");
-        ui.monospace(format!("{} {}", method, url));
-        ui.colored_label(egui::Color32::from_rgb(200, 0, 0), error);
+        ui.monospace(format!("{} {}", failure.method, failure.url));
+        if let Some(status) = failure.status {
+            ui.label(format!("Status: {}", status));
+        }
+        if let Some(duration_ms) = failure.duration_ms {
+            ui.label(format!("Duration: {} ms", duration_ms));
+        }
+        ui.colored_label(egui::Color32::from_rgb(200, 0, 0), &failure.error);
+
+        // 1. Display assertion results if any
+        if !failure.assertion_results.is_empty() {
+            ui.separator();
+            ui.label("🔍 Assertion Results:");
+            self.show_verbose_assertions(ui, &failure.assertion_results);
+        }
+
+        // 2. Display request body if present (skip if empty or whitespace only)
+        if let Some(request_body) = &failure.request_body
+            && !request_body.trim().is_empty()
+        {
+            ui.separator();
+            ui.label("Request Body:");
+            egui::ScrollArea::vertical()
+                .id_salt(format!("failure_request_body_{}", result_idx))
+                .max_height(150.0)
+                .show(ui, |ui| {
+                    ui.monospace(request_body);
+                });
+        }
+
+        // 3. Display response body if present (skip if empty or whitespace only)
+        if let Some(response_body) = &failure.response_body
+            && !response_body.trim().is_empty()
+        {
+            ui.separator();
+            ui.label("Response:");
+            egui::ScrollArea::vertical()
+                .id_salt(format!("failure_response_body_{}", result_idx))
+                .max_height(300.0)
+                .show(ui, |ui| {
+                    ui.monospace(response_body);
+                });
+        }
         ui.separator();
+    }
+
+    fn show_verbose_assertions(&self, ui: &mut egui::Ui, assertion_results: &[AssertionResult]) {
+        for assertion_result in assertion_results {
+            let assertion_type_str = match assertion_result.assertion.assertion_type {
+                httprunner_core::types::AssertionType::Status => "Status Code",
+                httprunner_core::types::AssertionType::Body => "Response Body",
+                httprunner_core::types::AssertionType::Headers => "Response Headers",
+            };
+
+            if assertion_result.passed {
+                ui.horizontal(|ui| {
+                    ui.colored_label(egui::Color32::from_rgb(0, 200, 0), "  ✅");
+                    ui.label(format!(
+                        "{}: Expected '{}'",
+                        assertion_type_str, assertion_result.assertion.expected_value
+                    ));
+                });
+            } else {
+                ui.horizontal(|ui| {
+                    ui.colored_label(egui::Color32::from_rgb(200, 0, 0), "  ❌");
+                    ui.label(format!(
+                        "{}: {}",
+                        assertion_type_str,
+                        assertion_result
+                            .error_message
+                            .as_ref()
+                            .unwrap_or(&"Failed".to_string())
+                    ));
+                });
+
+                if let Some(ref actual) = assertion_result.actual_value {
+                    ui.horizontal(|ui| {
+                        ui.label("     ");
+                        ui.colored_label(
+                            egui::Color32::from_rgb(255, 200, 0),
+                            format!("Expected: '{}'", assertion_result.assertion.expected_value),
+                        );
+                    });
+                    ui.horizontal(|ui| {
+                        ui.label("     ");
+                        ui.colored_label(
+                            egui::Color32::from_rgb(255, 200, 0),
+                            format!("Actual: '{}'", actual),
+                        );
+                    });
+                }
+            }
+        }
     }
 }
 

--- a/src/gui/src/results_view.rs
+++ b/src/gui/src/results_view.rs
@@ -449,7 +449,7 @@ impl ResultsView {
                         r.push(ExecutionResult::Failure(FailureResult::simple(
                             "INDEX".to_string(),
                             path.display().to_string(),
-                            format!("Request index {} not found", index),
+                            format!("Request index {} not found", index + 1),
                         )));
                     }
                 } else if let Ok(mut r) = results.lock() {

--- a/src/gui/src/results_view_async.rs
+++ b/src/gui/src/results_view_async.rs
@@ -1,5 +1,7 @@
 // WASM-specific async execution for results view
-use crate::results_view::{ExecutionResult, ResultsView, should_continue_after_async};
+use crate::results_view::{
+    ExecutionResult, FailureResult, ResultsView, should_continue_after_async,
+};
 use futures_util::FutureExt;
 use httprunner_core::parser;
 use httprunner_core::runner::{
@@ -73,11 +75,11 @@ impl ResultsView {
                         {
                             if let Ok(mut r) = results.lock() {
                                 r.clear();
-                                r.push(ExecutionResult::Failure {
-                                    method: "PROCESS".to_string(),
-                                    url: "content".to_string(),
-                                    error: format!("Async processing failed: {}", error),
-                                });
+                                r.push(ExecutionResult::Failure(FailureResult::simple(
+                                    "PROCESS".to_string(),
+                                    "content".to_string(),
+                                    format!("Async processing failed: {}", error),
+                                )));
                             }
                             ctx.request_repaint();
                         }
@@ -85,11 +87,11 @@ impl ResultsView {
                     Err(error) => {
                         if let Ok(mut r) = results.lock() {
                             r.clear();
-                            r.push(ExecutionResult::Failure {
-                                method: "PARSE".to_string(),
-                                url: "content".to_string(),
-                                error: format!("Failed to parse content: {}", error),
-                            });
+                            r.push(ExecutionResult::Failure(FailureResult::simple(
+                                "PARSE".to_string(),
+                                "content".to_string(),
+                                format!("Failed to parse content: {}", error),
+                            )));
                         }
                         ctx.request_repaint();
                     }
@@ -102,11 +104,11 @@ impl ResultsView {
                 let panic_message = panic_to_string(&panic);
                 if let Ok(mut r) = results.lock() {
                     r.clear();
-                    r.push(ExecutionResult::Failure {
-                        method: "PANIC".to_string(),
-                        url: "content".to_string(),
-                        error: format!("Async execution panicked: {}", panic_message),
-                    });
+                    r.push(ExecutionResult::Failure(FailureResult::simple(
+                        "PANIC".to_string(),
+                        "content".to_string(),
+                        format!("Async execution panicked: {}", panic_message),
+                    )));
                 }
             }
 
@@ -169,30 +171,30 @@ impl ResultsView {
                         if let Ok(mut r) = results.lock() {
                             r.clear();
                             if let Err(error) = process_result {
-                                r.push(ExecutionResult::Failure {
-                                    method: "PROCESS".to_string(),
-                                    url: "content".to_string(),
-                                    error: format!("Async processing failed: {}", error),
-                                });
+                                r.push(ExecutionResult::Failure(FailureResult::simple(
+                                    "PROCESS".to_string(),
+                                    "content".to_string(),
+                                    format!("Async processing failed: {}", error),
+                                )));
                             } else if let Some(result) = target_result {
                                 r.push(result);
                             } else {
-                                r.push(ExecutionResult::Failure {
-                                    method: "INDEX".to_string(),
-                                    url: "content".to_string(),
-                                    error: format!("Request index {} not found", index + 1),
-                                });
+                                r.push(ExecutionResult::Failure(FailureResult::simple(
+                                    "INDEX".to_string(),
+                                    "content".to_string(),
+                                    format!("Request index {} not found", index + 1),
+                                )));
                             }
                         }
                     }
                     Err(error) => {
                         if let Ok(mut r) = results.lock() {
                             r.clear();
-                            r.push(ExecutionResult::Failure {
-                                method: "PARSE".to_string(),
-                                url: "content".to_string(),
-                                error: format!("Failed to parse HTTP content: {}", error),
-                            });
+                            r.push(ExecutionResult::Failure(FailureResult::simple(
+                                "PARSE".to_string(),
+                                "content".to_string(),
+                                format!("Failed to parse HTTP content: {}", error),
+                            )));
                         }
                     }
                 }
@@ -204,11 +206,11 @@ impl ResultsView {
                 let panic_message = panic_to_string(&panic);
                 if let Ok(mut r) = results.lock() {
                     r.clear();
-                    r.push(ExecutionResult::Failure {
-                        method: "PANIC".to_string(),
-                        url: "content".to_string(),
-                        error: format!("Async execution panicked: {}", panic_message),
-                    });
+                    r.push(ExecutionResult::Failure(FailureResult::simple(
+                        "PANIC".to_string(),
+                        "content".to_string(),
+                        format!("Async execution panicked: {}", panic_message),
+                    )));
                 }
             }
 
@@ -248,19 +250,19 @@ fn make_async_executor(
 
 fn map_process_result(process_result: AsyncRequestProcessingResult) -> ExecutionResult {
     match process_result {
-        AsyncRequestProcessingResult::Skipped { request, reason } => ExecutionResult::Failure {
-            method: format!("⏭️ {}", request.method),
-            url: request.url,
-            error: format!("Skipped: {}", reason),
-        },
+        AsyncRequestProcessingResult::Skipped { request, reason } => {
+            ExecutionResult::Failure(FailureResult::simple(
+                format!("⏭️ {}", request.method),
+                request.url,
+                format!("Skipped: {}", reason),
+            ))
+        }
         AsyncRequestProcessingResult::Executed { request, result } => {
             map_http_result(request, result)
         }
-        AsyncRequestProcessingResult::Failed { request, error } => ExecutionResult::Failure {
-            method: request.method,
-            url: request.url,
-            error,
-        },
+        AsyncRequestProcessingResult::Failed { request, error } => {
+            ExecutionResult::Failure(FailureResult::simple(request.method, request.url, error))
+        }
     }
 }
 
@@ -276,12 +278,17 @@ fn map_http_result(request: HttpRequest, result: HttpResult) -> ExecutionResult 
             assertion_results: result.assertion_results,
         }
     } else {
-        ExecutionResult::Failure {
+        ExecutionResult::Failure(FailureResult {
             method: request.method,
             url: request.url,
             error: result
                 .error_message
                 .unwrap_or_else(|| "Unknown error".to_string()),
-        }
+            status: Some(result.status_code),
+            duration_ms: Some(result.duration_ms),
+            request_body: request.body,
+            response_body: result.response_body,
+            assertion_results: result.assertion_results,
+        })
     }
 }

--- a/src/gui/src/state.rs
+++ b/src/gui/src/state.rs
@@ -11,7 +11,7 @@ pub struct AppState {
     pub selected_environment: Option<String>,
     pub font_size: Option<f32>,
     pub window_size: Option<(f32, f32)>,
-    #[serde(skip_serializing)]
+    #[serde(skip)]
     pub last_results: Option<Vec<ExecutionResult>>,
     pub file_tree_visible: Option<bool>,
     pub results_compact_mode: Option<bool>,

--- a/src/tui/src/app.rs
+++ b/src/tui/src/app.rs
@@ -146,6 +146,7 @@ impl App {
                 return Ok(());
             }
             (KeyCode::Char('f'), KeyModifiers::NONE)
+            | (KeyCode::Char('F'), KeyModifiers::SHIFT)
                 if self.focused_pane != FocusedPane::EnvironmentEditor =>
             {
                 self.toggle_fail_fast();
@@ -355,10 +356,10 @@ impl App {
                                         skipped_count += 1;
                                         if let Ok(mut results) = incremental_results.lock() {
                                             results.push(
-                                                crate::results_view::ExecutionResult::Failure {
+                                                crate::results_view::ExecutionResult::Skipped {
                                                     method: format!("⏭️ {}", request.method),
                                                     url: request.url,
-                                                    error: format!("Skipped: {}", reason),
+                                                    reason,
                                                 },
                                             );
                                         }

--- a/src/tui/src/app.rs
+++ b/src/tui/src/app.rs
@@ -357,7 +357,7 @@ impl App {
                                         if let Ok(mut results) = incremental_results.lock() {
                                             results.push(
                                                 crate::results_view::ExecutionResult::Skipped {
-                                                    method: format!("⏭️ {}", request.method),
+                                                    method: request.method,
                                                     url: request.url,
                                                     reason,
                                                 },

--- a/src/tui/src/app.rs
+++ b/src/tui/src/app.rs
@@ -556,3 +556,42 @@ fn panic_to_string(panic: &Box<dyn Any + Send>) -> String {
 
     "unknown panic".to_string()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    fn key(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, modifiers)
+    }
+
+    #[test]
+    fn fail_fast_toggle_responds_to_lowercase_and_uppercase_f() {
+        let mut app = App::new().expect("App creation should not fail in tests");
+        assert!(!app.fail_fast, "fail_fast should default to false");
+
+        app.handle_key_event(key(KeyCode::Char('f'), KeyModifiers::NONE))
+            .unwrap();
+        assert!(app.fail_fast, "lowercase 'f' should toggle fail_fast on");
+        assert_eq!(app.status_message, "Fail-fast enabled");
+
+        app.handle_key_event(key(KeyCode::Char('F'), KeyModifiers::SHIFT))
+            .unwrap();
+        assert!(!app.fail_fast, "uppercase 'F' should toggle fail_fast off");
+        assert_eq!(app.status_message, "Fail-fast disabled");
+    }
+
+    #[test]
+    fn fail_fast_not_toggled_when_environment_editor_is_focused() {
+        let mut app = App::new().expect("App creation should not fail in tests");
+        app.focused_pane = FocusedPane::EnvironmentEditor;
+
+        app.handle_key_event(key(KeyCode::Char('f'), KeyModifiers::NONE))
+            .unwrap();
+        assert!(
+            !app.fail_fast,
+            "fail_fast should not toggle when environment editor is focused"
+        );
+    }
+}

--- a/src/tui/src/results_view.rs
+++ b/src/tui/src/results_view.rs
@@ -21,6 +21,11 @@ pub enum ExecutionResult {
         url: String,
         error: String,
     },
+    Skipped {
+        method: String,
+        url: String,
+        reason: String,
+    },
 }
 
 pub struct ResultsView {

--- a/src/tui/src/results_view.rs
+++ b/src/tui/src/results_view.rs
@@ -315,4 +315,68 @@ mod tests {
         results_view.apply_pending_verbose_switch();
         assert!(results_view.is_compact_mode());
     }
+
+    #[test]
+    fn skipped_results_are_not_counted_as_passed_or_failed() {
+        let mut results_view = ResultsView::new();
+        let arc = results_view.incremental_results();
+        let mut results = arc.lock().unwrap();
+        results.push(ExecutionResult::Success {
+            method: "GET".to_string(),
+            url: "https://example.com".to_string(),
+            status: 200,
+            duration_ms: 10,
+            request_body: None,
+            response_body: "ok".to_string(),
+            assertion_results: vec![],
+        });
+        results.push(ExecutionResult::Skipped {
+            method: "POST".to_string(),
+            url: "https://example.com/skip".to_string(),
+            reason: "dependency not met".to_string(),
+        });
+        results.push(ExecutionResult::Failure {
+            method: "DELETE".to_string(),
+            url: "https://example.com/fail".to_string(),
+            error: "404 Not Found".to_string(),
+        });
+        drop(results);
+
+        assert_eq!(results_view.passed_count(), 1);
+        assert_eq!(results_view.failed_count(), 1);
+    }
+
+    #[test]
+    fn get_incremental_results_returns_clone() {
+        let mut results_view = ResultsView::new();
+        assert!(results_view.get_incremental_results().is_empty());
+
+        results_view
+            .incremental_results()
+            .lock()
+            .unwrap()
+            .push(ExecutionResult::Skipped {
+                method: "GET".to_string(),
+                url: "https://example.com".to_string(),
+                reason: "condition false".to_string(),
+            });
+
+        let clone = results_view.get_incremental_results();
+        assert_eq!(clone.len(), 1);
+        assert!(matches!(clone[0], ExecutionResult::Skipped { .. }));
+    }
+
+    #[test]
+    fn skipped_variant_stores_bare_method_without_icon_prefix() {
+        // Ensure ExecutionResult::Skipped holds bare method (no embedded icon),
+        // because the renderer in ui.rs prepends its own icon.
+        let result = ExecutionResult::Skipped {
+            method: "GET".to_string(),
+            url: "https://example.com".to_string(),
+            reason: "condition".to_string(),
+        };
+        if let ExecutionResult::Skipped { method, .. } = result {
+            assert!(!method.contains('⏭'), "method should not embed the skip icon");
+        }
+    }
 }

--- a/src/tui/src/results_view.rs
+++ b/src/tui/src/results_view.rs
@@ -318,7 +318,7 @@ mod tests {
 
     #[test]
     fn skipped_results_are_not_counted_as_passed_or_failed() {
-        let mut results_view = ResultsView::new();
+        let results_view = ResultsView::new();
         let arc = results_view.incremental_results();
         let mut results = arc.lock().unwrap();
         results.push(ExecutionResult::Success {
@@ -348,7 +348,7 @@ mod tests {
 
     #[test]
     fn get_incremental_results_returns_clone() {
-        let mut results_view = ResultsView::new();
+        let results_view = ResultsView::new();
         assert!(results_view.get_incremental_results().is_empty());
 
         results_view

--- a/src/tui/src/ui.rs
+++ b/src/tui/src/ui.rs
@@ -447,6 +447,23 @@ fn render_results_view(f: &mut Frame, area: Rect, app: &App) {
                     ]));
                     lines.push(Line::from(""));
                 }
+                ExecutionResult::Skipped { method, url, reason } => {
+                    let method = sanitize_display_text(method);
+                    let url = sanitize_display_text(url);
+                    let reason = sanitize_display_text(reason);
+                    lines.push(Line::from(vec![
+                        Span::styled("⏭ ", Style::default().fg(Color::Yellow)),
+                        Span::raw(format!("{} {}", method, url)),
+                    ]));
+                    lines.push(Line::from(vec![
+                        Span::raw("  "),
+                        Span::styled(
+                            format!("Skipped: {}", reason),
+                            Style::default().fg(Color::Yellow),
+                        ),
+                    ]));
+                    lines.push(Line::from(""));
+                }
             }
         }
 
@@ -461,12 +478,25 @@ fn render_results_view(f: &mut Frame, area: Rect, app: &App) {
                 .iter()
                 .filter(|r| matches!(r, ExecutionResult::Failure { .. }))
                 .count();
-            lines.push(Line::from(vec![
+            let skipped = incremental_results
+                .iter()
+                .filter(|r| matches!(r, ExecutionResult::Skipped { .. }))
+                .count();
+            let mut summary_spans = vec![
                 Span::styled("Passed: ", Style::default().fg(Color::Green)),
                 Span::raw(format!("{} | ", passed)),
                 Span::styled("Failed: ", Style::default().fg(Color::Red)),
                 Span::raw(format!("{}", failed)),
-            ]));
+            ];
+            if skipped > 0 {
+                summary_spans.push(Span::raw(" | "));
+                summary_spans.push(Span::styled(
+                    "Skipped: ",
+                    Style::default().fg(Color::Yellow),
+                ));
+                summary_spans.push(Span::raw(format!("{}", skipped)));
+            }
+            lines.push(Line::from(summary_spans));
         }
 
         let title = if is_running {


### PR DESCRIPTION
Preserve full HTTP failure detail for verbose rendering in the GUI, render skipped requests separately in the TUI, and accept Shift+F for fail-fast toggle.

## Changes
- Carry status/body/assertion data in GUI failure results so verbose fail-fast view can render full detail.
- Add a distinct TUI skipped result instead of counting skips as failures.
- Accept uppercase F for the fail-fast toggle.

## Validation
- cargo build --workspace
- cargo check -p httprunner-gui --target wasm32-unknown-unknown
- cargo test -p httprunner-gui -p httprunner-tui
- cargo clippy -p httprunner-gui -p httprunner-tui --all-targets
- cargo clippy -p httprunner-gui --target wasm32-unknown-unknown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced results display with detailed failure information including status, duration, and request/response bodies.
  * Added visibility for skipped requests with reasons in results summary.
  * Added Shift+F keyboard shortcut support.

* **Bug Fixes**
  * Improved fail-fast mode coverage across all interfaces.

* **Chores**
  * Enhanced sensitive data protection in application state serialization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/christianhelle/httprunner/pull/269?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->