### PR TITLE
Unify request-level substitution into one module

### DIFF
--- a/src/core/src/lib.rs
+++ b/src/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod functions;
 pub mod logging;
 pub mod parser;
 mod redaction;
+mod request_substitution;
 pub mod report;
 pub mod runner;
 pub mod serializer;

--- a/src/core/src/processor/executor.rs
+++ b/src/core/src/processor/executor.rs
@@ -1,5 +1,5 @@
 use super::formatter::{format_json_if_valid, format_request_name};
-use super::substitution::{
+use crate::request_substitution::{
     substitute_functions_in_request, substitute_request_variables_in_request,
 };
 use crate::colors;

--- a/src/core/src/processor/incremental.rs
+++ b/src/core/src/processor/incremental.rs
@@ -1,4 +1,4 @@
-use super::substitution::{
+use crate::request_substitution::{
     substitute_functions_in_request, substitute_request_variables_in_request,
 };
 use crate::conditions;

--- a/src/core/src/processor/mod.rs
+++ b/src/core/src/processor/mod.rs
@@ -1,7 +1,6 @@
 mod executor;
 mod formatter;
 mod incremental;
-mod substitution;
 
 pub use executor::{
     ProcessorConfig, process_http_files, process_http_files_with_config,

--- a/src/core/src/processor/tests.rs
+++ b/src/core/src/processor/tests.rs
@@ -1,5 +1,5 @@
 use super::formatter::*;
-use super::substitution::*;
+use crate::request_substitution::*;
 use crate::types::{Header, HttpRequest, HttpResult, RequestContext};
 use std::collections::HashMap;
 

--- a/src/core/src/request_substitution.rs
+++ b/src/core/src/request_substitution.rs
@@ -1,4 +1,4 @@
-use crate::functions::substitute_functions;
+use crate::functions;
 use crate::types::{HttpRequest, RequestContext};
 use crate::variables;
 use anyhow::Result;
@@ -14,7 +14,7 @@ where
         header.value = substitutor(&header.value)?;
     }
 
-    if let Some(ref body) = request.body {
+    if let Some(body) = request.body.as_ref() {
         request.body = Some(substitutor(body)?);
     }
 
@@ -25,15 +25,15 @@ where
     Ok(())
 }
 
-pub fn substitute_request_variables_in_request(
+pub(crate) fn substitute_request_variables_in_request(
     request: &mut HttpRequest,
     context: &[RequestContext],
 ) -> Result<()> {
-    apply_substitution(request, |s| {
-        variables::substitute_request_variables(s, context)
+    apply_substitution(request, |value| {
+        variables::substitute_request_variables(value, context)
     })
 }
 
-pub fn substitute_functions_in_request(request: &mut HttpRequest) -> Result<()> {
-    apply_substitution(request, substitute_functions)
+pub(crate) fn substitute_functions_in_request(request: &mut HttpRequest) -> Result<()> {
+    apply_substitution(request, functions::substitute_functions)
 }

--- a/src/core/src/runner/incremental_async.rs
+++ b/src/core/src/runner/incremental_async.rs
@@ -1,7 +1,8 @@
 use crate::conditions;
-use crate::functions;
+use crate::request_substitution::{
+    substitute_functions_in_request, substitute_request_variables_in_request,
+};
 use crate::types::{HttpRequest, HttpResult, RequestContext};
-use crate::variables;
 use anyhow::Result;
 use std::future::Future;
 use std::pin::Pin;
@@ -198,41 +199,6 @@ where
     }
 
     Ok(())
-}
-
-fn apply_substitution<F>(request: &mut HttpRequest, substitutor: F) -> Result<()>
-where
-    F: Fn(&str) -> Result<String>,
-{
-    request.url = substitutor(&request.url)?;
-
-    for header in &mut request.headers {
-        header.name = substitutor(&header.name)?;
-        header.value = substitutor(&header.value)?;
-    }
-
-    if let Some(body) = request.body.as_ref() {
-        request.body = Some(substitutor(body)?);
-    }
-
-    for assertion in &mut request.assertions {
-        assertion.expected_value = substitutor(&assertion.expected_value)?;
-    }
-
-    Ok(())
-}
-
-fn substitute_request_variables_in_request(
-    request: &mut HttpRequest,
-    context: &[RequestContext],
-) -> Result<()> {
-    apply_substitution(request, |value| {
-        variables::substitute_request_variables(value, context)
-    })
-}
-
-fn substitute_functions_in_request(request: &mut HttpRequest) -> Result<()> {
-    apply_substitution(request, functions::substitute_functions)
 }
 
 fn add_request_context(


### PR DESCRIPTION
This pull request refactors the request substitution logic in the codebase to improve modularity and code organization. The main change is moving the substitution logic from the `processor` module to a new top-level module, `request_substitution`, and updating all relevant imports and usages throughout the codebase. This helps clarify the responsibilities of each module and makes the code easier to maintain.