### PR TITLE
Add support for URL encoding requests

### DIFF
--- a/examples/form-urlencoded.http
+++ b/examples/form-urlencoded.http
@@ -1,0 +1,66 @@
+# Example HTTP requests demonstrating application/x-www-form-urlencoded support
+# This file tests the fix for GitHub issue #271: spaces in form body values
+
+###
+# POST request with form-urlencoded body (no spaces)
+# @name form-no-spaces
+POST https://httpbin.org/post
+Content-Type: application/x-www-form-urlencoded
+
+username=testuser&password=testpass
+
+###
+# POST request with form-urlencoded body containing spaces
+# @name form-with-spaces
+POST https://httpbin.org/post
+Content-Type: application/x-www-form-urlencoded
+
+scope=scopea scopeb&grant_type=client_credentials
+
+###
+# POST request with form-urlencoded body containing special characters
+# @name form-with-special-chars
+POST https://httpbin.org/post
+Content-Type: application/x-www-form-urlencoded
+
+key=hello world!&redirect_uri=http://localhost:8080/callback&state=abc%20def
+
+###
+# POST request with form-urlencoded body containing ampersands in values
+# @name form-with-ampersands
+POST https://httpbin.org/post
+Content-Type: application/x-www-form-urlencoded
+
+query=foo&bar=test&value=a&b
+
+###
+# POST request with form-urlencoded body containing equals signs in values
+# @name form-with-equals
+POST https://httpbin.org/post
+Content-Type: application/x-www-form-urlencoded
+
+equation=a=b=c&normal=value
+
+###
+# POST request with form-urlencoded body and charset suffix
+# @name form-with-charset
+POST https://httpbin.org/post
+Content-Type: application/x-www-form-urlencoded; charset=utf-8
+
+scope=scopea scopeb&client_id=testid
+
+###
+# POST request with form-urlencoded body using uppercase Content-Type
+# @name form-uppercase-content-type
+POST https://httpbin.org/post
+Content-Type: APPLICATION/X-WWW-FORM-URLENCODED
+
+scope=scopea scopeb&grant_type=client_credentials
+
+###
+# POST request with form-urlencoded body containing OAuth-like scope
+# @name oauth-scope-example
+POST https://httpbin.org/post
+Content-Type: application/x-www-form-urlencoded
+
+grant_type=client_credentials&scope=openid profile email&client_id=myapp&client_secret=secret

--- a/examples/form-urlencoded.http
+++ b/examples/form-urlencoded.http
@@ -31,7 +31,7 @@ key=hello world!&redirect_uri=http://localhost:8080/callback&state=abc%20def
 POST https://httpbin.org/post
 Content-Type: application/x-www-form-urlencoded
 
-query=foo&bar=test&value=a&b
+query=foo&bar=test&value=a%26b
 
 ###
 # POST request with form-urlencoded body containing equals signs in values

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -30,9 +30,9 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 dirs = "6.0.0"
 uuid = { workspace = true }
- form_urlencoded = "1.2"
- pest = "2.8.6"
- pest_derive = "2.8.6"
+form_urlencoded = "1.2"
+pest = "2.8.6"
+pest_derive = "2.8.6"
 
 # Platform-specific dependencies (native)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/core/Cargo.toml
+++ b/src/core/Cargo.toml
@@ -30,8 +30,9 @@ base64 = { workspace = true }
 chrono = { workspace = true }
 dirs = "6.0.0"
 uuid = { workspace = true }
-pest = "2.8.6"
-pest_derive = "2.8.6"
+ form_urlencoded = "1.2"
+ pest = "2.8.6"
+ pest_derive = "2.8.6"
 
 # Platform-specific dependencies (native)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/src/core/src/runner/executor.rs
+++ b/src/core/src/runner/executor.rs
@@ -3,6 +3,7 @@ use super::response_processor::{
     build_error_result, build_success_result, build_temp_result_for_assertions, extract_headers,
     should_capture_response,
 };
+use super::{encode_form_body, needs_form_encoding};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::assertions;
 #[cfg(not(target_arch = "wasm32"))]
@@ -159,7 +160,12 @@ fn build_request(
     }
 
     if let Some(ref body) = request.body {
-        req_builder = req_builder.body(body.clone());
+        let body = if needs_form_encoding(&request.headers) {
+            encode_form_body(body)
+        } else {
+            body.clone()
+        };
+        req_builder = req_builder.body(body);
     }
 
     Ok(req_builder)

--- a/src/core/src/runner/executor_async.rs
+++ b/src/core/src/runner/executor_async.rs
@@ -2,8 +2,9 @@ use super::response_processor::{
     build_error_result, build_success_result, build_temp_result_for_assertions, extract_headers,
     should_capture_response,
 };
+use super::{encode_form_body, needs_form_encoding};
 use crate::assertions;
-use crate::types::{HttpRequest, HttpResult};
+use crate::types::{Header, HttpRequest, HttpResult};
 use anyhow::Result;
 use reqwest::Client;
 use std::collections::HashMap;
@@ -116,7 +117,12 @@ fn build_request_async(client: &Client, request: &HttpRequest) -> Result<reqwest
     }
 
     if let Some(ref body) = request.body {
-        req_builder = req_builder.body(body.clone());
+        let body = if needs_form_encoding(&request.headers) {
+            encode_form_body(body)
+        } else {
+            body.clone()
+        };
+        req_builder = req_builder.body(body);
     }
 
     Ok(req_builder)

--- a/src/core/src/runner/mod.rs
+++ b/src/core/src/runner/mod.rs
@@ -1,6 +1,9 @@
 mod executor;
 mod incremental_async;
 mod response_processor;
+mod url_encoding;
+
+pub use url_encoding::{encode_form_body, needs_form_encoding};
 
 #[cfg(target_arch = "wasm32")]
 mod executor_async;

--- a/src/core/src/runner/url_encoding.rs
+++ b/src/core/src/runner/url_encoding.rs
@@ -2,10 +2,31 @@ use crate::types::Header;
 
 /// Encodes a body as application/x-www-form-urlencoded content.
 ///
-/// Spaces are encoded as `+`, and special characters are percent-encoded
+/// Splits the body by `&` (form field separator), then for each field splits
+/// by the first `=` (key-value delimiter). Only the value is encoded — the
+/// key and structural characters (`&`, `=`) are preserved.
+///
+/// Spaces are encoded as `+`, and other special characters are percent-encoded
 /// according to RFC 1866 (application/x-www-form-urlencoded).
 pub fn encode_form_body(body: &str) -> String {
-    form_urlencoded::byte_serialize(body.as_bytes()).collect()
+    if body.is_empty() {
+        return String::new();
+    }
+
+    let encoded: Vec<String> = body
+        .split('&')
+        .map(|field| {
+            if let Some((key, value)) = field.split_once('=') {
+                let encoded_value =
+                    form_urlencoded::byte_serialize(value.as_bytes()).collect::<String>();
+                format!("{}={}", key, encoded_value)
+            } else {
+                field.to_string()
+            }
+        })
+        .collect();
+
+    encoded.join("&")
 }
 
 /// Checks if the request headers indicate `application/x-www-form-urlencoded`
@@ -32,28 +53,28 @@ mod tests {
     fn test_encode_form_body_encodes_spaces_as_plus() {
         let input = "scope=scopea scopeb";
         let result = encode_form_body(input);
-        assert_eq!(result, "scope%3Dscopea+scopeb");
+        assert_eq!(result, "scope=scopea+scopeb");
     }
 
     #[test]
-    fn test_encode_form_body_preserves_already_encoded_chars() {
-        let input = "key=value%20encoded";
-        let result = encode_form_body(input);
-        assert_eq!(result, "key%3Dvalue%2520encoded");
-    }
-
-    #[test]
-    fn test_encode_form_body_handles_ampersands() {
+    fn test_encode_form_body_preserves_ampersands() {
         let input = "a=1&b=2";
         let result = encode_form_body(input);
-        assert_eq!(result, "a%3D1%26b%3D2");
+        assert_eq!(result, "a=1&b=2");
     }
 
     #[test]
-    fn test_encode_form_body_handles_equals_signs() {
-        let input = "key=value=pair";
+    fn test_encode_form_body_encodes_spaces_in_values() {
+        let input = "scope=scopea scopeb&grant_type=client_credentials";
         let result = encode_form_body(input);
-        assert_eq!(result, "key%3Dvalue%3Dpair");
+        assert_eq!(result, "scope=scopea+scopeb&grant_type=client_credentials");
+    }
+
+    #[test]
+    fn test_encode_form_body_handles_equals_in_values() {
+        let input = "equation=a=b=c&normal=value";
+        let result = encode_form_body(input);
+        assert_eq!(result, "equation=a%3Db%3Dc&normal=value");
     }
 
     #[test]
@@ -74,7 +95,14 @@ mod tests {
     fn test_encode_form_body_no_special_chars_unchanged() {
         let input = "abc=123&xyz=456";
         let result = encode_form_body(input);
-        assert_eq!(result, "abc%3D123%26xyz%3D456");
+        assert_eq!(result, "abc=123&xyz=456");
+    }
+
+    #[test]
+    fn test_encode_form_body_preserves_keys() {
+        let input = "username=testuser&password=testpass";
+        let result = encode_form_body(input);
+        assert_eq!(result, "username=testuser&password=testpass");
     }
 
     #[test]
@@ -82,6 +110,33 @@ mod tests {
         let input = "name=test%20value";
         let result = encode_form_body(input);
         assert!(!result.contains(' '));
+    }
+
+    #[test]
+    fn test_encode_form_body_field_without_equals() {
+        let input = "flag&key=value";
+        let result = encode_form_body(input);
+        assert_eq!(result, "flag&key=value");
+    }
+
+    #[test]
+    fn test_encode_form_body_oauth_scope() {
+        let input = "grant_type=client_credentials&scope=openid profile email&client_id=myapp";
+        let result = encode_form_body(input);
+        assert_eq!(
+            result,
+            "grant_type=client_credentials&scope=openid+profile+email&client_id=myapp"
+        );
+    }
+
+    #[test]
+    fn test_encode_form_body_redirect_uri() {
+        let input = "redirect_uri=http://localhost:8080/callback";
+        let result = encode_form_body(input);
+        assert_eq!(
+            result,
+            "redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fcallback"
+        );
     }
 
     #[test]

--- a/src/core/src/runner/url_encoding.rs
+++ b/src/core/src/runner/url_encoding.rs
@@ -2,12 +2,17 @@ use crate::types::Header;
 
 /// Encodes a body as application/x-www-form-urlencoded content.
 ///
-/// Splits the body by `&` (form field separator), then for each field splits
-/// by the first `=` (key-value delimiter). Only the value is encoded — the
-/// key and structural characters (`&`, `=`) are preserved.
+/// The input must already use `&` exclusively as field separators. Any `&` characters
+/// inside field values must be percent-encoded as `%26` before calling this function.
+/// This function encodes only values (not keys or structural characters).
+/// Malformed fields without `=` are left unchanged.
 ///
 /// Spaces are encoded as `+`, and other special characters are percent-encoded
 /// according to RFC 1866 (application/x-www-form-urlencoded).
+///
+/// Splits the body by `&` (form field separator), then for each field splits
+/// by the first `=` (key-value delimiter). Only the value is encoded — the
+/// key and structural characters (`&`, `=`) are preserved.
 pub fn encode_form_body(body: &str) -> String {
     if body.is_empty() {
         return String::new();
@@ -17,8 +22,26 @@ pub fn encode_form_body(body: &str) -> String {
         .split('&')
         .map(|field| {
             if let Some((key, value)) = field.split_once('=') {
-                let encoded_value =
-                    form_urlencoded::byte_serialize(value.as_bytes()).collect::<String>();
+                let encoded_value = if value.chars().any(|c| c == '%') {
+                    let mut has_encoded = false;
+                    let bytes = value.as_bytes();
+                    for i in 0..bytes.len().saturating_sub(2) {
+                        if bytes[i] == b'%'
+                            && bytes[i + 1].is_ascii_hexdigit()
+                            && bytes[i + 2].is_ascii_hexdigit()
+                        {
+                            has_encoded = true;
+                            break;
+                        }
+                    }
+                    if has_encoded {
+                        value.to_string()
+                    } else {
+                        form_urlencoded::byte_serialize(bytes).collect::<String>()
+                    }
+                } else {
+                    form_urlencoded::byte_serialize(value.as_bytes()).collect::<String>()
+                };
                 format!("{}={}", key, encoded_value)
             } else {
                 field.to_string()
@@ -106,10 +129,14 @@ mod tests {
     }
 
     #[test]
-    fn test_encode_form_body_with_unicode() {
-        let input = "name=test%20value";
+    fn test_encode_form_body_no_double_encoding() {
+        let input = "state=abc%20def";
         let result = encode_form_body(input);
-        assert!(!result.contains(' '));
+        assert_eq!(result, "state=abc%20def");
+
+        let input2 = "key=a b";
+        let result2 = encode_form_body(input2);
+        assert_eq!(result2, "key=a+b");
     }
 
     #[test]

--- a/src/core/src/runner/url_encoding.rs
+++ b/src/core/src/runner/url_encoding.rs
@@ -22,25 +22,26 @@ pub fn encode_form_body(body: &str) -> String {
         .split('&')
         .map(|field| {
             if let Some((key, value)) = field.split_once('=') {
-                let encoded_value = if value.chars().any(|c| c == '%') {
-                    let mut has_encoded = false;
+                let encoded_value = {
                     let bytes = value.as_bytes();
-                    for i in 0..bytes.len().saturating_sub(2) {
-                        if bytes[i] == b'%'
+                    let mut result = String::new();
+                    let mut i = 0;
+                    while i < bytes.len() {
+                        if i + 2 < bytes.len()
+                            && bytes[i] == b'%'
                             && bytes[i + 1].is_ascii_hexdigit()
                             && bytes[i + 2].is_ascii_hexdigit()
                         {
-                            has_encoded = true;
-                            break;
+                            result.push_str(&value[i..i + 3]);
+                            i += 3;
+                        } else {
+                            result.push_str(
+                                &form_urlencoded::byte_serialize(&[bytes[i]]).collect::<String>(),
+                            );
+                            i += 1;
                         }
                     }
-                    if has_encoded {
-                        value.to_string()
-                    } else {
-                        form_urlencoded::byte_serialize(bytes).collect::<String>()
-                    }
-                } else {
-                    form_urlencoded::byte_serialize(value.as_bytes()).collect::<String>()
+                    result
                 };
                 format!("{}={}", key, encoded_value)
             } else {
@@ -137,6 +138,10 @@ mod tests {
         let input2 = "key=a b";
         let result2 = encode_form_body(input2);
         assert_eq!(result2, "key=a+b");
+
+        let input3 = "state=abc%20def ghi";
+        let result3 = encode_form_body(input3);
+        assert_eq!(result3, "state=abc%20def+ghi");
     }
 
     #[test]

--- a/src/core/src/runner/url_encoding.rs
+++ b/src/core/src/runner/url_encoding.rs
@@ -1,0 +1,152 @@
+use crate::types::Header;
+
+/// Encodes a body as application/x-www-form-urlencoded content.
+///
+/// Spaces are encoded as `+`, and special characters are percent-encoded
+/// according to RFC 1866 (application/x-www-form-urlencoded).
+pub fn encode_form_body(body: &str) -> String {
+    form_urlencoded::byte_serialize(body.as_bytes()).collect()
+}
+
+/// Checks if the request headers indicate `application/x-www-form-urlencoded`
+/// content type.
+///
+/// Returns `true` if any header named "Content-Type" (case-insensitive) has a
+/// value starting with `application/x-www-form-urlencoded`.
+pub fn needs_form_encoding(headers: &[Header]) -> bool {
+    headers.iter().any(|h| {
+        if h.name.to_lowercase() != "content-type" {
+            return false;
+        }
+        h.value
+            .to_lowercase()
+            .starts_with("application/x-www-form-urlencoded")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_form_body_encodes_spaces_as_plus() {
+        let input = "scope=scopea scopeb";
+        let result = encode_form_body(input);
+        assert_eq!(result, "scope%3Dscopea+scopeb");
+    }
+
+    #[test]
+    fn test_encode_form_body_preserves_already_encoded_chars() {
+        let input = "key=value%20encoded";
+        let result = encode_form_body(input);
+        assert_eq!(result, "key%3Dvalue%2520encoded");
+    }
+
+    #[test]
+    fn test_encode_form_body_handles_ampersands() {
+        let input = "a=1&b=2";
+        let result = encode_form_body(input);
+        assert_eq!(result, "a%3D1%26b%3D2");
+    }
+
+    #[test]
+    fn test_encode_form_body_handles_equals_signs() {
+        let input = "key=value=pair";
+        let result = encode_form_body(input);
+        assert_eq!(result, "key%3Dvalue%3Dpair");
+    }
+
+    #[test]
+    fn test_encode_form_body_handles_special_characters() {
+        let input = "key=hello world!@#$%";
+        let result = encode_form_body(input);
+        assert!(!result.contains(' '));
+        assert!(result.contains('%'));
+    }
+
+    #[test]
+    fn test_encode_form_body_empty_string() {
+        let result = encode_form_body("");
+        assert_eq!(result, "");
+    }
+
+    #[test]
+    fn test_encode_form_body_no_special_chars_unchanged() {
+        let input = "abc=123&xyz=456";
+        let result = encode_form_body(input);
+        assert_eq!(result, "abc%3D123%26xyz%3D456");
+    }
+
+    #[test]
+    fn test_encode_form_body_with_unicode() {
+        let input = "name=test%20value";
+        let result = encode_form_body(input);
+        assert!(!result.contains(' '));
+    }
+
+    #[test]
+    fn test_needs_form_encoding_with_form_content_type() {
+        let headers = vec![Header {
+            name: "Content-Type".to_string(),
+            value: "application/x-www-form-urlencoded".to_string(),
+        }];
+        assert!(needs_form_encoding(&headers));
+    }
+
+    #[test]
+    fn test_needs_form_encoding_with_charset() {
+        let headers = vec![Header {
+            name: "Content-Type".to_string(),
+            value: "application/x-www-form-urlencoded; charset=utf-8".to_string(),
+        }];
+        assert!(needs_form_encoding(&headers));
+    }
+
+    #[test]
+    fn test_needs_form_encoding_case_insensitive() {
+        let headers = vec![Header {
+            name: "content-type".to_string(),
+            value: "APPLICATION/X-WWW-FORM-URLENCODED".to_string(),
+        }];
+        assert!(needs_form_encoding(&headers));
+    }
+
+    #[test]
+    fn test_needs_form_encoding_with_json_content_type() {
+        let headers = vec![Header {
+            name: "Content-Type".to_string(),
+            value: "application/json".to_string(),
+        }];
+        assert!(!needs_form_encoding(&headers));
+    }
+
+    #[test]
+    fn test_needs_form_encoding_with_no_content_type() {
+        let headers: Vec<Header> = vec![];
+        assert!(!needs_form_encoding(&headers));
+    }
+
+    #[test]
+    fn test_needs_form_encoding_with_other_header() {
+        let headers = vec![Header {
+            name: "Authorization".to_string(),
+            value: "Bearer token".to_string(),
+        }];
+        assert!(!needs_form_encoding(&headers));
+    }
+
+    #[test]
+    fn test_needs_form_encoding_with_multiple_headers() {
+        let headers = vec![
+            Header {
+                name: "Authorization".to_string(),
+                value: "Bearer token".to_string(),
+            },
+            Header {
+                name: "Content-Type".to_string(),
+                value: "application/x-www-form-urlencoded".to_string(),
+            },
+        ];
+        assert!(needs_form_encoding(&headers));
+    }
+}

--- a/src/gui/src/results_view.rs
+++ b/src/gui/src/results_view.rs
@@ -1,8 +1,8 @@
 #[cfg(not(target_arch = "wasm32"))]
-use httprunner_core::telemetry;
+use httprunner_core::processor::RequestProcessingResult;
 use httprunner_core::runner::AsyncRequestProcessingResult;
 #[cfg(not(target_arch = "wasm32"))]
-use httprunner_core::processor::RequestProcessingResult;
+use httprunner_core::telemetry;
 use httprunner_core::types::AssertionResult;
 use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -365,8 +365,7 @@ impl ResultsView {
                                 // Only capture the result for the target index
                                 if idx == index {
                                     use httprunner_core::processor::RequestProcessingResult;
-                                    let is_failure =
-                                        !should_continue_after(&process_result, true);
+                                    let is_failure = !should_continue_after(&process_result, true);
                                     target_result = Some(match process_result {
                                         RequestProcessingResult::Skipped { request, reason } => {
                                             ExecutionResult::Failure(FailureResult::simple(
@@ -509,9 +508,7 @@ impl ResultsView {
             ui.separator();
 
             ui.checkbox(&mut self.fail_fast, "Fail-fast")
-                .on_hover_text(
-                    "Stop the run at the first failed request and show it in verbose",
-                );
+                .on_hover_text("Stop the run at the first failed request and show it in verbose");
 
             ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                 ui.label(

--- a/src/tui/src/app.rs
+++ b/src/tui/src/app.rs
@@ -344,11 +344,10 @@ impl App {
                             |_idx, total, process_result| {
                                 total_count = total;
 
-                                let should_continue =
-                                    crate::results_view::should_continue_after(
-                                        &process_result,
-                                        fail_fast,
-                                    );
+                                let should_continue = crate::results_view::should_continue_after(
+                                    &process_result,
+                                    fail_fast,
+                                );
 
                                 use httprunner_core::processor::RequestProcessingResult;
                                 match process_result {
@@ -415,10 +414,8 @@ impl App {
                                 // Fail-fast: halt on the first failing result and
                                 // request the view to switch to verbose.
                                 if !should_continue {
-                                    switch_to_verbose.store(
-                                        true,
-                                        std::sync::atomic::Ordering::SeqCst,
-                                    );
+                                    switch_to_verbose
+                                        .store(true, std::sync::atomic::Ordering::SeqCst);
                                 }
                                 should_continue
                             },

--- a/src/tui/src/results_view.rs
+++ b/src/tui/src/results_view.rs
@@ -376,7 +376,10 @@ mod tests {
             reason: "condition".to_string(),
         };
         if let ExecutionResult::Skipped { method, .. } = result {
-            assert!(!method.contains('⏭'), "method should not embed the skip icon");
+            assert!(
+                !method.contains('⏭'),
+                "method should not embed the skip icon"
+            );
         }
     }
 }

--- a/src/tui/src/ui.rs
+++ b/src/tui/src/ui.rs
@@ -447,7 +447,11 @@ fn render_results_view(f: &mut Frame, area: Rect, app: &App) {
                     ]));
                     lines.push(Line::from(""));
                 }
-                ExecutionResult::Skipped { method, url, reason } => {
+                ExecutionResult::Skipped {
+                    method,
+                    url,
+                    reason,
+                } => {
                     let method = sanitize_display_text(method);
                     let url = sanitize_display_text(url);
                     let reason = sanitize_display_text(reason);
@@ -830,9 +834,7 @@ fn render_status_bar(f: &mut Frame, area: Rect, app: &App) {
             if app.fail_fast {
                 Span::styled(
                     "Fail-fast: ON",
-                    Style::default()
-                        .fg(Color::Red)
-                        .add_modifier(Modifier::BOLD),
+                    Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
                 )
             } else {
                 Span::styled("Fail-fast: OFF", Style::default().fg(Color::DarkGray))


### PR DESCRIPTION
Fixes #271 

- **Add form_urlencoded dependency and url_encoding module**
- **Auto-encode form bodies when Content-Type is application/x-www-form-urlencoded**
- **Fix form encoding to preserve structural characters (ampersands, equals)**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * application/x-www-form-urlencoded bodies are now encoded correctly (spaces as +, special chars percent-encoded) and avoid double-encoding; Content-Type casing and charset parameters are respected.
* **New Features**
  * Form-encoding is applied consistently for both sync and async requests.
* **Tests**
  * Added example requests covering many form-encoding edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->