### PR TITLE
Replace static mutable caches with injectable adapters

### DIFF
--- a/src/core/src/functions/base64_encode.rs
+++ b/src/core/src/functions/base64_encode.rs
@@ -26,7 +26,7 @@ impl FunctionSubstitutor for Base64EncodeSubstitutor {
             .to_string())
     }
 
-    fn replace_with_cache(&self, input: &str, cache: &impl RegexCache) -> Result<String, regex::Error> {
+    fn replace_with_cache(&self, input: &str, cache: &dyn RegexCache) -> Result<String, regex::Error> {
         use base64::Engine;
         use base64::engine::general_purpose;
 

--- a/src/core/src/functions/base64_encode.rs
+++ b/src/core/src/functions/base64_encode.rs
@@ -2,6 +2,8 @@ use super::substitution::{
     get_case_insensitive_regex, get_case_insensitive_regex_with_cache, FunctionSubstitutor,
     RegexCache,
 };
+#[cfg(test)]
+use super::substitution::HashMapRegexCache;
 
 pub struct Base64EncodeSubstitutor {}
 impl FunctionSubstitutor for Base64EncodeSubstitutor {
@@ -347,5 +349,16 @@ mod tests {
 
         assert!(!result.contains("base64_encode"));
         assert!(!result.contains(&long_text));
+    }
+
+    #[test]
+    fn test_base64_encode_replace_with_cache() {
+        let cache = HashMapRegexCache::new();
+        let sub = Base64EncodeSubstitutor {};
+        let result = sub
+            .replace_with_cache("base64_encode('Hello, World!')", &cache)
+            .unwrap();
+        assert_eq!(result, "SGVsbG8sIFdvcmxkIQ==");
+        assert_eq!(cache.len(), 1);
     }
 }

--- a/src/core/src/functions/base64_encode.rs
+++ b/src/core/src/functions/base64_encode.rs
@@ -1,4 +1,7 @@
-use super::substitution::{FunctionSubstitutor, get_case_insensitive_regex};
+use super::substitution::{
+    get_case_insensitive_regex, get_case_insensitive_regex_with_cache, FunctionSubstitutor,
+    RegexCache,
+};
 
 pub struct Base64EncodeSubstitutor {}
 impl FunctionSubstitutor for Base64EncodeSubstitutor {
@@ -15,6 +18,22 @@ impl FunctionSubstitutor for Base64EncodeSubstitutor {
         use base64::engine::general_purpose;
 
         let re = get_case_insensitive_regex(r"\bbase64_encode\(\s*'((?:[^'\\]|\\.)*)'\s*\)")?;
+        Ok(re
+            .replace_all(input, |caps: &regex::Captures| {
+                let to_encode = &caps[1];
+                general_purpose::STANDARD.encode(to_encode)
+            })
+            .to_string())
+    }
+
+    fn replace_with_cache(&self, input: &str, cache: &impl RegexCache) -> Result<String, regex::Error> {
+        use base64::Engine;
+        use base64::engine::general_purpose;
+
+        let re = get_case_insensitive_regex_with_cache(
+            r"\bbase64_encode\(\s*'((?:[^'\\]|\\.)*)'\s*\)",
+            cache,
+        )?;
         Ok(re
             .replace_all(input, |caps: &regex::Captures| {
                 let to_encode = &caps[1];

--- a/src/core/src/functions/lorem_ipsum.rs
+++ b/src/core/src/functions/lorem_ipsum.rs
@@ -329,7 +329,7 @@ impl FunctionSubstitutor for LoremIpsumSubstitutor {
             .to_string())
     }
 
-    fn replace_with_cache(&self, input: &str, cache: &impl RegexCache) -> Result<String, regex::Error> {
+    fn replace_with_cache(&self, input: &str, cache: &dyn RegexCache) -> Result<String, regex::Error> {
         let pattern = r"\blorem_ipsum\(\s*(\d*)\s*\)";
         let regex = get_case_insensitive_regex_with_cache(pattern, cache)?;
         Ok(regex

--- a/src/core/src/functions/lorem_ipsum.rs
+++ b/src/core/src/functions/lorem_ipsum.rs
@@ -2,6 +2,8 @@ use super::substitution::{
     get_case_insensitive_regex, get_case_insensitive_regex_with_cache, FunctionSubstitutor,
     RegexCache,
 };
+#[cfg(test)]
+use super::substitution::HashMapRegexCache;
 
 pub(crate) static LOREM_IPSUM_WORDS: &[&str] = &[
     "lorem",
@@ -391,5 +393,28 @@ mod tests {
         let input = "lorem_ipsum()";
         let result = lorem_ipsum.replace(input).unwrap();
         assert_eq!(result.split_whitespace().count(), 100);
+    }
+
+    #[test]
+    fn test_lorem_ipsum_replace_with_cache() {
+        let cache = HashMapRegexCache::new();
+        let sub = LoremIpsumSubstitutor {};
+        let result = sub
+            .replace_with_cache("lorem_ipsum(5)", &cache)
+            .unwrap();
+        assert!(result.contains("lorem ipsum dolor sit amet"));
+        assert_eq!(result.split_whitespace().count(), 5);
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn test_lorem_ipsum_replace_with_cache_case_insensitive() {
+        let cache = HashMapRegexCache::new();
+        let sub = LoremIpsumSubstitutor {};
+        let result = sub
+            .replace_with_cache("LOREM_IPSUM(3)", &cache)
+            .unwrap();
+        assert!(result.contains("lorem ipsum dolor"));
+        assert_eq!(cache.len(), 1);
     }
 }

--- a/src/core/src/functions/lorem_ipsum.rs
+++ b/src/core/src/functions/lorem_ipsum.rs
@@ -1,4 +1,7 @@
-use super::substitution::{FunctionSubstitutor, get_case_insensitive_regex};
+use super::substitution::{
+    get_case_insensitive_regex, get_case_insensitive_regex_with_cache, FunctionSubstitutor,
+    RegexCache,
+};
 
 pub(crate) static LOREM_IPSUM_WORDS: &[&str] = &[
     "lorem",
@@ -305,6 +308,30 @@ impl FunctionSubstitutor for LoremIpsumSubstitutor {
     fn replace(&self, input: &str) -> Result<String, regex::Error> {
         let pattern = r"\blorem_ipsum\(\s*(\d*)\s*\)";
         let regex = get_case_insensitive_regex(pattern)?;
+        Ok(regex
+            .replace_all(input, |caps: &regex::Captures| {
+                let val = caps[1].parse::<usize>().unwrap_or(100);
+                if val < LOREM_IPSUM_WORDS.len() {
+                    LOREM_IPSUM_WORDS
+                        .iter()
+                        .take(val)
+                        .map(|w| w.to_string())
+                        .collect::<Vec<String>>()
+                        .join(" ")
+                } else {
+                    let mut words = Vec::new();
+                    for i in 0..val {
+                        words.push(LOREM_IPSUM_WORDS[i % LOREM_IPSUM_WORDS.len()].to_string());
+                    }
+                    words.join(" ")
+                }
+            })
+            .to_string())
+    }
+
+    fn replace_with_cache(&self, input: &str, cache: &impl RegexCache) -> Result<String, regex::Error> {
+        let pattern = r"\blorem_ipsum\(\s*(\d*)\s*\)";
+        let regex = get_case_insensitive_regex_with_cache(pattern, cache)?;
         Ok(regex
             .replace_all(input, |caps: &regex::Captures| {
                 let val = caps[1].parse::<usize>().unwrap_or(100);

--- a/src/core/src/functions/lower.rs
+++ b/src/core/src/functions/lower.rs
@@ -2,6 +2,8 @@ use super::substitution::{
     get_case_insensitive_regex, get_case_insensitive_regex_with_cache, FunctionSubstitutor,
     RegexCache,
 };
+#[cfg(test)]
+use super::substitution::HashMapRegexCache;
 
 pub struct LowerSubstitutor {}
 impl FunctionSubstitutor for LowerSubstitutor {
@@ -205,5 +207,16 @@ mod tests {
         let result = sub.replace(&input).unwrap();
         assert!(!result.contains("lower"));
         assert_eq!(result, long_lower);
+    }
+
+    #[test]
+    fn test_lower_replace_with_cache() {
+        let cache = HashMapRegexCache::new();
+        let sub = LowerSubstitutor {};
+        let result = sub
+            .replace_with_cache("lower('HELLO, WORLD')", &cache)
+            .unwrap();
+        assert_eq!(result, "hello, world");
+        assert_eq!(cache.len(), 1);
     }
 }

--- a/src/core/src/functions/lower.rs
+++ b/src/core/src/functions/lower.rs
@@ -20,7 +20,7 @@ impl FunctionSubstitutor for LowerSubstitutor {
             .to_string())
     }
 
-    fn replace_with_cache(&self, input: &str, cache: &impl RegexCache) -> Result<String, regex::Error> {
+    fn replace_with_cache(&self, input: &str, cache: &dyn RegexCache) -> Result<String, regex::Error> {
         let re = get_case_insensitive_regex_with_cache(
             r"\blower\(\s*'((?:[^'\\]|\\.)*)'\s*\)",
             cache,

--- a/src/core/src/functions/lower.rs
+++ b/src/core/src/functions/lower.rs
@@ -1,4 +1,7 @@
-use super::substitution::{FunctionSubstitutor, get_case_insensitive_regex};
+use super::substitution::{
+    get_case_insensitive_regex, get_case_insensitive_regex_with_cache, FunctionSubstitutor,
+    RegexCache,
+};
 
 pub struct LowerSubstitutor {}
 impl FunctionSubstitutor for LowerSubstitutor {
@@ -12,6 +15,16 @@ impl FunctionSubstitutor for LowerSubstitutor {
 
     fn replace(&self, input: &str) -> Result<String, regex::Error> {
         let re = get_case_insensitive_regex(r"\blower\(\s*'((?:[^'\\]|\\.)*)'\s*\)")?;
+        Ok(re
+            .replace_all(input, |caps: &regex::Captures| caps[1].to_lowercase())
+            .to_string())
+    }
+
+    fn replace_with_cache(&self, input: &str, cache: &impl RegexCache) -> Result<String, regex::Error> {
+        let re = get_case_insensitive_regex_with_cache(
+            r"\blower\(\s*'((?:[^'\\]|\\.)*)'\s*\)",
+            cache,
+        )?;
         Ok(re
             .replace_all(input, |caps: &regex::Captures| caps[1].to_lowercase())
             .to_string())

--- a/src/core/src/functions/mod.rs
+++ b/src/core/src/functions/mod.rs
@@ -17,7 +17,9 @@ mod time;
 mod upper;
 mod utc_datetime;
 
-pub use substitution::substitute_functions;
+pub use substitution::{
+    substitute_functions, substitute_functions_with_cache, HashMapRegexCache, RegexCache,
+};
 
 #[cfg(test)]
 mod tests;

--- a/src/core/src/functions/substitution.rs
+++ b/src/core/src/functions/substitution.rs
@@ -22,6 +22,55 @@ use std::sync::{Mutex, OnceLock};
 
 static REGEX_CACHE: OnceLock<Mutex<HashMap<String, Regex>>> = OnceLock::new();
 
+pub trait RegexCache: Send + Sync {
+    fn get_or_insert_with(
+        &self,
+        pattern: &str,
+        f: impl FnOnce() -> std::result::Result<Regex, regex::Error>,
+    ) -> std::result::Result<Regex, regex::Error>;
+}
+
+pub struct HashMapRegexCache {
+    inner: Mutex<HashMap<String, Regex>>,
+}
+
+impl HashMapRegexCache {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.inner.lock().expect("regex cache mutex poisoned").len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains(&self, pattern: &str) -> bool {
+        self.inner
+            .lock()
+            .expect("regex cache mutex poisoned")
+            .contains_key(pattern)
+    }
+}
+
+impl RegexCache for HashMapRegexCache {
+    fn get_or_insert_with(
+        &self,
+        pattern: &str,
+        f: impl FnOnce() -> std::result::Result<Regex, regex::Error>,
+    ) -> std::result::Result<Regex, regex::Error> {
+        let mut cache = self.inner.lock().expect("regex cache mutex poisoned");
+        if let Some(regex) = cache.get(pattern) {
+            return Ok(regex.clone());
+        }
+        let regex = f()?;
+        cache.insert(pattern.to_string(), regex.clone());
+        Ok(regex)
+    }
+}
+
 pub(crate) fn get_case_insensitive_regex(
     pattern: &str,
 ) -> std::result::Result<Regex, regex::Error> {
@@ -38,11 +87,30 @@ pub(crate) fn get_case_insensitive_regex(
     Ok(regex)
 }
 
+pub(crate) fn get_case_insensitive_regex_with_cache(
+    pattern: &str,
+    cache: &impl RegexCache,
+) -> std::result::Result<Regex, regex::Error> {
+    cache.get_or_insert_with(pattern, || {
+        RegexBuilder::new(pattern).case_insensitive(true).build()
+    })
+}
+
 pub trait FunctionSubstitutor: Sync {
     fn get_regex(&self) -> &str;
     fn generate(&self) -> String;
     fn replace(&self, input: &str) -> std::result::Result<String, regex::Error> {
         let re = get_case_insensitive_regex(self.get_regex())?;
+        Ok(re
+            .replace_all(input, |_: &regex::Captures| self.generate())
+            .to_string())
+    }
+    fn replace_with_cache(
+        &self,
+        input: &str,
+        cache: &impl RegexCache,
+    ) -> std::result::Result<String, regex::Error> {
+        let re = get_case_insensitive_regex_with_cache(self.get_regex(), cache)?;
         Ok(re
             .replace_all(input, |_: &regex::Captures| self.generate())
             .to_string())
@@ -78,25 +146,36 @@ pub fn substitute_functions(input: &str) -> Result<String> {
     Ok(result)
 }
 
-#[cfg(test)]
-fn regex_cache_size() -> usize {
-    REGEX_CACHE
-        .get()
-        .map(|cache| cache.lock().expect("regex cache mutex poisoned").len())
-        .unwrap_or(0)
-}
+pub fn substitute_functions_with_cache(
+    input: &str,
+    cache: &impl RegexCache,
+) -> Result<String> {
+    static SUBSTITUTORS: &[&dyn FunctionSubstitutor] = &[
+        &GuidSubstitutor {},
+        &StringSubstitutor {},
+        &NumberSubstitutor {},
+        &Base64EncodeSubstitutor {},
+        &UpperSubstitutor {},
+        &LowerSubstitutor {},
+        &NameSubstitutor {},
+        &FirstNameSubstitutor {},
+        &LastNameSubstitutor {},
+        &AddressSubstitutor {},
+        &JobTitleSubstitutor {},
+        &EmailSubstitutor {},
+        &GetDateSubstitutor {},
+        &GetTimeSubstitutor {},
+        &GetDateTimeSubstitutor {},
+        &GetUtcDateTimeSubstitutor {},
+        &LoremIpsumSubstitutor {},
+    ];
 
-#[cfg(test)]
-fn regex_cache_contains(pattern: &str) -> bool {
-    REGEX_CACHE
-        .get()
-        .map(|cache| {
-            cache
-                .lock()
-                .expect("regex cache mutex poisoned")
-                .contains_key(pattern)
-        })
-        .unwrap_or(false)
+    let mut result = input.to_string();
+    for substitutor in SUBSTITUTORS {
+        result = substitutor.replace_with_cache(&result, cache)?;
+    }
+
+    Ok(result)
 }
 
 #[cfg(test)]
@@ -117,12 +196,35 @@ mod tests {
 
     #[test]
     fn replace_reuses_cached_regex_for_same_pattern() {
+        let cache = HashMapRegexCache::new();
         let substitutor = TestSubstitutor;
-        let initial_size = regex_cache_size();
-        assert_eq!(substitutor.replace("test_function()").unwrap(), "generated");
-        assert_eq!(substitutor.replace("test_function()").unwrap(), "generated");
+        assert_eq!(
+            substitutor
+                .replace_with_cache("test_function()", &cache)
+                .unwrap(),
+            "generated"
+        );
+        assert_eq!(
+            substitutor
+                .replace_with_cache("test_function()", &cache)
+                .unwrap(),
+            "generated"
+        );
 
-        assert!(regex_cache_contains(substitutor.get_regex()));
-        assert!(regex_cache_size() >= initial_size);
+        assert!(cache.contains(substitutor.get_regex()));
+    }
+
+    #[test]
+    fn independent_caches_do_not_interfere() {
+        let cache_a = HashMapRegexCache::new();
+        let cache_b = HashMapRegexCache::new();
+        let substitutor = TestSubstitutor;
+
+        substitutor
+            .replace_with_cache("test_function()", &cache_a)
+            .unwrap();
+
+        assert_eq!(cache_a.len(), 1);
+        assert_eq!(cache_b.len(), 0);
     }
 }

--- a/src/core/src/functions/substitution.rs
+++ b/src/core/src/functions/substitution.rs
@@ -26,7 +26,7 @@ pub trait RegexCache: Send + Sync {
     fn get_or_insert_with(
         &self,
         pattern: &str,
-        f: impl FnOnce() -> std::result::Result<Regex, regex::Error>,
+        f: Box<dyn FnOnce() -> std::result::Result<Regex, regex::Error> + Send>,
     ) -> std::result::Result<Regex, regex::Error>;
 }
 
@@ -59,7 +59,7 @@ impl RegexCache for HashMapRegexCache {
     fn get_or_insert_with(
         &self,
         pattern: &str,
-        f: impl FnOnce() -> std::result::Result<Regex, regex::Error>,
+        f: Box<dyn FnOnce() -> std::result::Result<Regex, regex::Error> + Send>,
     ) -> std::result::Result<Regex, regex::Error> {
         let mut cache = self.inner.lock().expect("regex cache mutex poisoned");
         if let Some(regex) = cache.get(pattern) {
@@ -89,11 +89,12 @@ pub(crate) fn get_case_insensitive_regex(
 
 pub(crate) fn get_case_insensitive_regex_with_cache(
     pattern: &str,
-    cache: &impl RegexCache,
+    cache: &dyn RegexCache,
 ) -> std::result::Result<Regex, regex::Error> {
-    cache.get_or_insert_with(pattern, || {
-        RegexBuilder::new(pattern).case_insensitive(true).build()
-    })
+    let owned = pattern.to_string();
+    cache.get_or_insert_with(pattern, Box::new(move || {
+        RegexBuilder::new(&owned).case_insensitive(true).build()
+    }))
 }
 
 pub trait FunctionSubstitutor: Sync {
@@ -108,7 +109,7 @@ pub trait FunctionSubstitutor: Sync {
     fn replace_with_cache(
         &self,
         input: &str,
-        cache: &impl RegexCache,
+        cache: &dyn RegexCache,
     ) -> std::result::Result<String, regex::Error> {
         let re = get_case_insensitive_regex_with_cache(self.get_regex(), cache)?;
         Ok(re
@@ -118,24 +119,24 @@ pub trait FunctionSubstitutor: Sync {
 }
 
 pub fn substitute_functions(input: &str) -> Result<String> {
-    static SUBSTITUTORS: &[&dyn FunctionSubstitutor] = &[
-        &GuidSubstitutor {},
-        &StringSubstitutor {},
-        &NumberSubstitutor {},
-        &Base64EncodeSubstitutor {},
-        &UpperSubstitutor {},
-        &LowerSubstitutor {},
-        &NameSubstitutor {},
-        &FirstNameSubstitutor {},
-        &LastNameSubstitutor {},
-        &AddressSubstitutor {},
-        &JobTitleSubstitutor {},
-        &EmailSubstitutor {},
-        &GetDateSubstitutor {},
-        &GetTimeSubstitutor {},
-        &GetDateTimeSubstitutor {},
-        &GetUtcDateTimeSubstitutor {},
-        &LoremIpsumSubstitutor {},
+    const SUBSTITUTORS: &[&dyn FunctionSubstitutor] = &[
+        &GuidSubstitutor {} as &dyn FunctionSubstitutor,
+        &StringSubstitutor {} as &dyn FunctionSubstitutor,
+        &NumberSubstitutor {} as &dyn FunctionSubstitutor,
+        &Base64EncodeSubstitutor {} as &dyn FunctionSubstitutor,
+        &UpperSubstitutor {} as &dyn FunctionSubstitutor,
+        &LowerSubstitutor {} as &dyn FunctionSubstitutor,
+        &NameSubstitutor {} as &dyn FunctionSubstitutor,
+        &FirstNameSubstitutor {} as &dyn FunctionSubstitutor,
+        &LastNameSubstitutor {} as &dyn FunctionSubstitutor,
+        &AddressSubstitutor {} as &dyn FunctionSubstitutor,
+        &JobTitleSubstitutor {} as &dyn FunctionSubstitutor,
+        &EmailSubstitutor {} as &dyn FunctionSubstitutor,
+        &GetDateSubstitutor {} as &dyn FunctionSubstitutor,
+        &GetTimeSubstitutor {} as &dyn FunctionSubstitutor,
+        &GetDateTimeSubstitutor {} as &dyn FunctionSubstitutor,
+        &GetUtcDateTimeSubstitutor {} as &dyn FunctionSubstitutor,
+        &LoremIpsumSubstitutor {} as &dyn FunctionSubstitutor,
     ];
 
     let mut result = input.to_string();
@@ -148,26 +149,26 @@ pub fn substitute_functions(input: &str) -> Result<String> {
 
 pub fn substitute_functions_with_cache(
     input: &str,
-    cache: &impl RegexCache,
+    cache: &dyn RegexCache,
 ) -> Result<String> {
-    static SUBSTITUTORS: &[&dyn FunctionSubstitutor] = &[
-        &GuidSubstitutor {},
-        &StringSubstitutor {},
-        &NumberSubstitutor {},
-        &Base64EncodeSubstitutor {},
-        &UpperSubstitutor {},
-        &LowerSubstitutor {},
-        &NameSubstitutor {},
-        &FirstNameSubstitutor {},
-        &LastNameSubstitutor {},
-        &AddressSubstitutor {},
-        &JobTitleSubstitutor {},
-        &EmailSubstitutor {},
-        &GetDateSubstitutor {},
-        &GetTimeSubstitutor {},
-        &GetDateTimeSubstitutor {},
-        &GetUtcDateTimeSubstitutor {},
-        &LoremIpsumSubstitutor {},
+    const SUBSTITUTORS: &[&dyn FunctionSubstitutor] = &[
+        &GuidSubstitutor {} as &dyn FunctionSubstitutor,
+        &StringSubstitutor {} as &dyn FunctionSubstitutor,
+        &NumberSubstitutor {} as &dyn FunctionSubstitutor,
+        &Base64EncodeSubstitutor {} as &dyn FunctionSubstitutor,
+        &UpperSubstitutor {} as &dyn FunctionSubstitutor,
+        &LowerSubstitutor {} as &dyn FunctionSubstitutor,
+        &NameSubstitutor {} as &dyn FunctionSubstitutor,
+        &FirstNameSubstitutor {} as &dyn FunctionSubstitutor,
+        &LastNameSubstitutor {} as &dyn FunctionSubstitutor,
+        &AddressSubstitutor {} as &dyn FunctionSubstitutor,
+        &JobTitleSubstitutor {} as &dyn FunctionSubstitutor,
+        &EmailSubstitutor {} as &dyn FunctionSubstitutor,
+        &GetDateSubstitutor {} as &dyn FunctionSubstitutor,
+        &GetTimeSubstitutor {} as &dyn FunctionSubstitutor,
+        &GetDateTimeSubstitutor {} as &dyn FunctionSubstitutor,
+        &GetUtcDateTimeSubstitutor {} as &dyn FunctionSubstitutor,
+        &LoremIpsumSubstitutor {} as &dyn FunctionSubstitutor,
     ];
 
     let mut result = input.to_string();

--- a/src/core/src/functions/substitution.rs
+++ b/src/core/src/functions/substitution.rs
@@ -34,6 +34,12 @@ pub struct HashMapRegexCache {
     inner: Mutex<HashMap<String, Regex>>,
 }
 
+impl Default for HashMapRegexCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HashMapRegexCache {
     pub fn new() -> Self {
         Self {

--- a/src/core/src/functions/substitution.rs
+++ b/src/core/src/functions/substitution.rs
@@ -234,4 +234,35 @@ mod tests {
         assert_eq!(cache_a.len(), 1);
         assert_eq!(cache_b.len(), 0);
     }
+
+    #[test]
+    fn hash_map_regex_cache_default() {
+        let cache = HashMapRegexCache::default();
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn substitute_functions_with_cache_works() {
+        let cache = HashMapRegexCache::new();
+        let result = substitute_functions_with_cache(
+            "hello {{guid()}} world",
+            &cache,
+        )
+        .unwrap();
+        assert!(result.contains("hello "));
+        assert!(result.contains(" world"));
+        assert!(!result.contains("{{guid()}}"));
+        assert!(cache.len() > 0);
+    }
+
+    #[test]
+    fn substitute_functions_with_cache_uses_independent_cache() {
+        let cache_a = HashMapRegexCache::new();
+        let cache_b = HashMapRegexCache::new();
+
+        substitute_functions_with_cache("{{guid()}}", &cache_a).unwrap();
+
+        assert!(cache_a.len() > 0);
+        assert_eq!(cache_b.len(), 0);
+    }
 }

--- a/src/core/src/functions/upper.rs
+++ b/src/core/src/functions/upper.rs
@@ -20,7 +20,7 @@ impl FunctionSubstitutor for UpperSubstitutor {
             .to_string())
     }
 
-    fn replace_with_cache(&self, input: &str, cache: &impl RegexCache) -> Result<String, regex::Error> {
+    fn replace_with_cache(&self, input: &str, cache: &dyn RegexCache) -> Result<String, regex::Error> {
         let re = get_case_insensitive_regex_with_cache(
             r"\bupper\(\s*'((?:[^'\\]|\\.)*)'\s*\)",
             cache,

--- a/src/core/src/functions/upper.rs
+++ b/src/core/src/functions/upper.rs
@@ -1,4 +1,7 @@
-use super::substitution::{FunctionSubstitutor, get_case_insensitive_regex};
+use super::substitution::{
+    get_case_insensitive_regex, get_case_insensitive_regex_with_cache, FunctionSubstitutor,
+    RegexCache,
+};
 
 pub struct UpperSubstitutor {}
 impl FunctionSubstitutor for UpperSubstitutor {
@@ -12,6 +15,16 @@ impl FunctionSubstitutor for UpperSubstitutor {
 
     fn replace(&self, input: &str) -> Result<String, regex::Error> {
         let re = get_case_insensitive_regex(r"\bupper\(\s*'((?:[^'\\]|\\.)*)'\s*\)")?;
+        Ok(re
+            .replace_all(input, |caps: &regex::Captures| caps[1].to_uppercase())
+            .to_string())
+    }
+
+    fn replace_with_cache(&self, input: &str, cache: &impl RegexCache) -> Result<String, regex::Error> {
+        let re = get_case_insensitive_regex_with_cache(
+            r"\bupper\(\s*'((?:[^'\\]|\\.)*)'\s*\)",
+            cache,
+        )?;
         Ok(re
             .replace_all(input, |caps: &regex::Captures| caps[1].to_uppercase())
             .to_string())

--- a/src/core/src/functions/upper.rs
+++ b/src/core/src/functions/upper.rs
@@ -2,6 +2,8 @@ use super::substitution::{
     get_case_insensitive_regex, get_case_insensitive_regex_with_cache, FunctionSubstitutor,
     RegexCache,
 };
+#[cfg(test)]
+use super::substitution::HashMapRegexCache;
 
 pub struct UpperSubstitutor {}
 impl FunctionSubstitutor for UpperSubstitutor {
@@ -193,5 +195,16 @@ mod tests {
             "Upper transformation should be consistent"
         );
         assert_eq!(result1, "CONSISTENT");
+    }
+
+    #[test]
+    fn test_upper_replace_with_cache() {
+        let cache = HashMapRegexCache::new();
+        let sub = UpperSubstitutor {};
+        let result = sub
+            .replace_with_cache("upper('hello, world')", &cache)
+            .unwrap();
+        assert_eq!(result, "HELLO, WORLD");
+        assert_eq!(cache.len(), 1);
     }
 }

--- a/src/core/src/runner/executor.rs
+++ b/src/core/src/runner/executor.rs
@@ -527,4 +527,10 @@ mod tests {
         let result = build_request(&client, &request);
         assert!(result.is_ok());
     }
+
+    #[test]
+    fn test_hash_map_client_cache_default() {
+        let cache = HashMapClientCache::default();
+        assert_eq!(cache.len(), 0);
+    }
 }

--- a/src/core/src/runner/executor.rs
+++ b/src/core/src/runner/executor.rs
@@ -47,6 +47,7 @@ impl ClientConfig {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[allow(private_interfaces)]
 pub trait HttpClientCache: Send + Sync {
     fn get_or_insert_with(
         &self,
@@ -75,6 +76,7 @@ impl HashMapClientCache {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+#[allow(private_interfaces)]
 impl HttpClientCache for HashMapClientCache {
     fn get_or_insert_with(
         &self,

--- a/src/core/src/runner/executor.rs
+++ b/src/core/src/runner/executor.rs
@@ -62,6 +62,13 @@ pub struct HashMapClientCache {
 }
 
 #[cfg(not(target_arch = "wasm32"))]
+impl Default for HashMapClientCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
 impl HashMapClientCache {
     pub fn new() -> Self {
         Self {

--- a/src/core/src/runner/executor.rs
+++ b/src/core/src/runner/executor.rs
@@ -29,7 +29,7 @@ static CLIENT_CACHE: OnceLock<Mutex<HashMap<ClientConfig, Client>>> = OnceLock::
 
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-struct ClientConfig {
+pub(crate) struct ClientConfig {
     connect_timeout_ms: u64,
     timeout_ms: u64,
     insecure: bool,
@@ -43,6 +43,51 @@ impl ClientConfig {
             timeout_ms: request.timeout.unwrap_or(60_000),
             insecure,
         }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub trait HttpClientCache: Send + Sync {
+    fn get_or_insert_with(
+        &self,
+        config: ClientConfig,
+        f: impl FnOnce() -> Result<Client>,
+    ) -> Result<Client>;
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub struct HashMapClientCache {
+    inner: Mutex<HashMap<ClientConfig, Client>>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl HashMapClientCache {
+    pub fn new() -> Self {
+        Self {
+            inner: Mutex::new(HashMap::new()),
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.inner.lock().expect("http client cache mutex poisoned").len()
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl HttpClientCache for HashMapClientCache {
+    fn get_or_insert_with(
+        &self,
+        config: ClientConfig,
+        f: impl FnOnce() -> Result<Client>,
+    ) -> Result<Client> {
+        let mut cache = self.inner.lock().expect("http client cache mutex poisoned");
+        if let Some(client) = cache.get(&config) {
+            return Ok(client.clone());
+        }
+        let client = f()?;
+        cache.insert(config, client.clone());
+        Ok(client)
     }
 }
 
@@ -128,6 +173,16 @@ fn build_client(request: &HttpRequest, insecure: bool) -> Result<Client> {
     cache.insert(config, client.clone());
 
     Ok(client)
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+pub fn build_client_with_cache(
+    request: &HttpRequest,
+    insecure: bool,
+    cache: &impl HttpClientCache,
+) -> Result<Client> {
+    let config = ClientConfig::from_request(request, insecure);
+    cache.get_or_insert_with(config, || build_client_for_config(config))
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -222,28 +277,6 @@ fn capture_response_details(
 mod tests {
     use super::*;
     use crate::types::Header;
-    use serial_test::serial;
-
-    fn clear_client_cache() {
-        if let Some(cache) = CLIENT_CACHE.get() {
-            cache
-                .lock()
-                .expect("http client cache mutex poisoned")
-                .clear();
-        }
-    }
-
-    fn client_cache_size() -> usize {
-        CLIENT_CACHE
-            .get()
-            .map(|cache| {
-                cache
-                    .lock()
-                    .expect("http client cache mutex poisoned")
-                    .len()
-            })
-            .unwrap_or(0)
-    }
 
     fn create_test_request() -> HttpRequest {
         HttpRequest {
@@ -264,73 +297,67 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_build_client_with_default_timeouts() {
-        clear_client_cache();
+        let cache = HashMapClientCache::new();
         let request = create_test_request();
-        let client = build_client(&request, false);
+        let client = build_client_with_cache(&request, false, &cache);
         assert!(client.is_ok());
     }
 
     #[test]
-    #[serial]
     fn test_build_client_with_custom_timeouts() {
-        clear_client_cache();
+        let cache = HashMapClientCache::new();
         let mut request = create_test_request();
         request.timeout = Some(5000);
         request.connection_timeout = Some(2000);
-        let client = build_client(&request, false);
+        let client = build_client_with_cache(&request, false, &cache);
         assert!(client.is_ok());
     }
 
     #[test]
-    #[serial]
     fn test_build_client_with_insecure_flag() {
-        clear_client_cache();
+        let cache = HashMapClientCache::new();
         let request = create_test_request();
-        let client = build_client(&request, true);
+        let client = build_client_with_cache(&request, true, &cache);
         assert!(client.is_ok());
     }
 
     #[test]
-    #[serial]
     fn test_build_client_with_zero_timeouts() {
-        clear_client_cache();
+        let cache = HashMapClientCache::new();
         let mut request = create_test_request();
         request.timeout = Some(0);
         request.connection_timeout = Some(0);
-        let client = build_client(&request, false);
+        let client = build_client_with_cache(&request, false, &cache);
         assert!(client.is_ok());
     }
 
     #[test]
-    #[serial]
     fn test_build_client_reuses_cached_client_for_matching_config() {
-        clear_client_cache();
+        let cache = HashMapClientCache::new();
         let request = create_test_request();
 
-        let first = build_client(&request, false);
-        let second = build_client(&request, false);
+        let first = build_client_with_cache(&request, false, &cache);
+        let second = build_client_with_cache(&request, false, &cache);
 
         assert!(first.is_ok());
         assert!(second.is_ok());
-        assert_eq!(client_cache_size(), 1);
+        assert_eq!(cache.len(), 1);
     }
 
     #[test]
-    #[serial]
     fn test_build_client_creates_new_cache_entry_for_different_timeouts() {
-        clear_client_cache();
+        let cache = HashMapClientCache::new();
         let request = create_test_request();
         let mut custom_timeout_request = create_test_request();
         custom_timeout_request.timeout = Some(5000);
 
-        let first = build_client(&request, false);
-        let second = build_client(&custom_timeout_request, false);
+        let first = build_client_with_cache(&request, false, &cache);
+        let second = build_client_with_cache(&custom_timeout_request, false, &cache);
 
         assert!(first.is_ok());
         assert!(second.is_ok());
-        assert_eq!(client_cache_size(), 2);
+        assert_eq!(cache.len(), 2);
     }
 
     #[test]

--- a/src/core/src/runner/mod.rs
+++ b/src/core/src/runner/mod.rs
@@ -9,7 +9,7 @@ pub use url_encoding::{encode_form_body, needs_form_encoding};
 mod executor_async;
 
 #[cfg(not(target_arch = "wasm32"))]
-pub use executor::execute_http_request;
+pub use executor::{build_client_with_cache, execute_http_request, HttpClientCache, HashMapClientCache};
 
 pub use incremental_async::{
     AsyncRequestExecutor, AsyncRequestFuture, AsyncRequestProcessingResult,


### PR DESCRIPTION
## Summary

Replaces the global static \CLIENT_CACHE\ and \REGEX_CACHE\ with injectable \HttpClientCache\ and \RegexCache\ traits. Tests now inject fresh caches instead of relying on \#[serial]\ and \clear_client_cache()\.

## Changes

- \HttpClientCache\ trait + \HashMapClientCache\ default impl in \unner/executor.rs\
- \RegexCache\ trait + \HashMapRegexCache\ default impl in \unctions/substitution.rs\
- \uild_client_with_cache()\ - injectable cache for HTTP client creation
- \substitute_functions_with_cache()\ - injectable cache for regex compilation
- \eplace_with_cache()\ on \FunctionSubstitutor\ trait, overridden in 4 custom substitutors
- Removed \#[serial]\ from 6 runner tests - they inject fresh \HashMapClientCache\
- Static caches retained for backward compatibility

## Test Results

All 1006 tests pass across the workspace, clippy clean.