### PR TITLE
refactor(core): collapse process_http_files into one interface

### DIFF
--- a/src/cli/src/main.rs
+++ b/src/cli/src/main.rs
@@ -107,17 +107,18 @@ fn load_files(cli_args: &cli::Cli) -> Result<Vec<String>> {
 }
 
 fn process_http_files(cli_args: &cli::Cli, files: Vec<String>) -> Result<ProcessorResults> {
-    let results = processor::process_http_files_with_options(
-        &files,
-        cli_args.verbose,
-        cli_args.get_log_filename().as_deref(),
-        cli_args.env.as_deref(),
-        cli_args.insecure,
-        cli_args.pretty_json,
-        cli_args.delay,
-        cli_args.include_secrets,
-        cli_args.fail_fast,
-    )?;
+    let log_filename = cli_args.get_log_filename();
+    let config = processor::ProcessorConfig::new(&files)
+        .with_verbose(cli_args.verbose)
+        .with_log_filename(log_filename.as_deref())
+        .with_environment(cli_args.env.as_deref())
+        .with_insecure(cli_args.insecure)
+        .with_pretty_json(cli_args.pretty_json)
+        .with_delay(cli_args.delay)
+        .with_include_secrets(cli_args.include_secrets)
+        .with_fail_fast(cli_args.fail_fast);
+
+    let results = processor::process_http_files(&config, &processor::default_executor)?;
 
     if results.success {
         println!(

--- a/src/core/README.md
+++ b/src/core/README.md
@@ -60,19 +60,19 @@ fn main() -> anyhow::Result<()> {
 ### High-level API (Process Multiple Files)
 
 ```rust
-use httprunner_core::processor::process_http_files;
+use httprunner_core::processor::{ProcessorConfig, default_executor, process_http_files};
 
 fn main() -> anyhow::Result<()> {
     // Process one or more .http files
     let files = vec!["example.http".to_string()];
-    let results = process_http_files(
-        &files,
-        false,  // verbose
-        None,   // log_filename
-        None,   // environment
-        false,  // insecure
-        false,  // pretty_json
-    )?;
+
+    // Configure options via the builder (all default to the values shown)
+    let config = ProcessorConfig::new(&files)
+        .with_verbose(false)
+        .with_pretty_json(false);
+
+    // `default_executor` performs real blocking HTTP requests
+    let results = process_http_files(&config, &default_executor)?;
     
     // Calculate totals from file results
     let total_success: u32 = results.files.iter().map(|f| f.success_count).sum();

--- a/src/core/src/processor/README.md
+++ b/src/core/src/processor/README.md
@@ -13,16 +13,17 @@ This module handles the execution of HTTP requests from parsed HTTP files, inclu
 ## Usage
 
 ```rust
-use crate::processor::process_http_files;
+use crate::processor::{ProcessorConfig, default_executor, process_http_files};
 
-let results = process_http_files(
-    &["requests.http"],
-    true,  // verbose
-    Some("output.log"),
-    Some("dev"),  // environment
-    false,  // insecure
-    true    // pretty_json
-)?;
+let files = vec!["requests.http".to_string()];
+let config = ProcessorConfig::new(&files)
+    .with_verbose(true)
+    .with_log_filename(Some("output.log"))
+    .with_environment(Some("dev"))
+    .with_insecure(false)
+    .with_pretty_json(true);
+
+let results = process_http_files(&config, &default_executor)?;
 ```
 
 ## Features

--- a/src/core/src/processor/executor.rs
+++ b/src/core/src/processor/executor.rs
@@ -418,28 +418,6 @@ where
     ))
 }
 
-pub fn process_http_files(
-    files: &[String],
-    verbose: bool,
-    log_filename: Option<&str>,
-    environment: Option<&str>,
-    insecure: bool,
-    pretty_json: bool,
-    delay_ms: u64,
-) -> Result<ProcessorResults> {
-    let config = ProcessorConfig::new(files)
-        .with_verbose(verbose)
-        .with_log_filename(log_filename)
-        .with_environment(environment)
-        .with_insecure(insecure)
-        .with_pretty_json(pretty_json)
-        .with_delay(delay_ms);
-
-    process_http_files_with_config(&config, &|request, verbose, insecure| {
-        runner::execute_http_request(request, verbose, insecure)
-    })
-}
-
 #[allow(clippy::too_many_arguments)]
 pub fn process_http_files_with_options(
     files: &[String],

--- a/src/core/src/processor/executor.rs
+++ b/src/core/src/processor/executor.rs
@@ -473,6 +473,15 @@ where
     process_http_files(&config, executor)
 }
 
+/// The default executor: performs real blocking HTTP requests.
+pub fn default_executor(
+    request: &HttpRequest,
+    verbose: bool,
+    insecure: bool,
+) -> Result<HttpResult> {
+    runner::execute_http_request(request, verbose, insecure)
+}
+
 pub fn process_http_files<F>(
     config: &ProcessorConfig,
     executor: &F,

--- a/src/core/src/processor/executor.rs
+++ b/src/core/src/processor/executor.rs
@@ -418,61 +418,6 @@ where
     ))
 }
 
-#[allow(clippy::too_many_arguments)]
-pub fn process_http_files_with_options(
-    files: &[String],
-    verbose: bool,
-    log_filename: Option<&str>,
-    environment: Option<&str>,
-    insecure: bool,
-    pretty_json: bool,
-    delay_ms: u64,
-    include_secrets: bool,
-    fail_fast: bool,
-) -> Result<ProcessorResults> {
-    let config = ProcessorConfig::new(files)
-        .with_verbose(verbose)
-        .with_log_filename(log_filename)
-        .with_environment(environment)
-        .with_insecure(insecure)
-        .with_pretty_json(pretty_json)
-        .with_delay(delay_ms)
-        .with_include_secrets(include_secrets)
-        .with_fail_fast(fail_fast);
-
-    process_http_files(&config, &|request, verbose, insecure| {
-        runner::execute_http_request(request, verbose, insecure)
-    })
-}
-
-pub fn process_http_files_with_silent(config: &ProcessorConfig) -> Result<ProcessorResults> {
-    process_http_files(config, &|request, verbose, insecure| {
-        runner::execute_http_request(request, verbose, insecure)
-    })
-}
-
-pub fn process_http_files_with_executor<F>(
-    files: &[String],
-    verbose: bool,
-    log_filename: Option<&str>,
-    environment: Option<&str>,
-    insecure: bool,
-    pretty_json: bool,
-    executor: &F,
-) -> Result<ProcessorResults>
-where
-    F: Fn(&HttpRequest, bool, bool) -> Result<HttpResult>,
-{
-    let config = ProcessorConfig::new(files)
-        .with_verbose(verbose)
-        .with_log_filename(log_filename)
-        .with_environment(environment)
-        .with_insecure(insecure)
-        .with_pretty_json(pretty_json);
-
-    process_http_files(&config, executor)
-}
-
 /// The default executor: performs real blocking HTTP requests.
 pub fn default_executor(
     request: &HttpRequest,

--- a/src/core/src/processor/executor.rs
+++ b/src/core/src/processor/executor.rs
@@ -440,13 +440,13 @@ pub fn process_http_files_with_options(
         .with_include_secrets(include_secrets)
         .with_fail_fast(fail_fast);
 
-    process_http_files_with_config(&config, &|request, verbose, insecure| {
+    process_http_files(&config, &|request, verbose, insecure| {
         runner::execute_http_request(request, verbose, insecure)
     })
 }
 
 pub fn process_http_files_with_silent(config: &ProcessorConfig) -> Result<ProcessorResults> {
-    process_http_files_with_config(config, &|request, verbose, insecure| {
+    process_http_files(config, &|request, verbose, insecure| {
         runner::execute_http_request(request, verbose, insecure)
     })
 }
@@ -470,10 +470,10 @@ where
         .with_insecure(insecure)
         .with_pretty_json(pretty_json);
 
-    process_http_files_with_config(&config, executor)
+    process_http_files(&config, executor)
 }
 
-pub fn process_http_files_with_config<F>(
+pub fn process_http_files<F>(
     config: &ProcessorConfig,
     executor: &F,
 ) -> Result<ProcessorResults>

--- a/src/core/src/processor/executor_tests.rs
+++ b/src/core/src/processor/executor_tests.rs
@@ -4,7 +4,7 @@ use tempfile::NamedTempFile;
 #[cfg(test)]
 mod tests {
     use super::super::executor::{
-        ProcessorConfig, process_http_files_with_config, process_http_files_with_executor,
+        ProcessorConfig, process_http_files, process_http_files_with_executor,
     };
     use super::super::mock_executor::MockHttpExecutor;
     use super::*;
@@ -675,7 +675,7 @@ Content-Type: application/json
             .with_silent(true);
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
-        let result = process_http_files_with_config(&config, &|req, v, i| mock.execute(req, v, i));
+        let result = process_http_files(&config, &|req, v, i| mock.execute(req, v, i));
 
         assert!(result.is_ok());
 
@@ -720,7 +720,7 @@ Content-Type: application/json
             .with_silent(true);
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
-        let result = process_http_files_with_config(&config, &|req, v, i| mock.execute(req, v, i));
+        let result = process_http_files(&config, &|req, v, i| mock.execute(req, v, i));
 
         assert!(result.is_ok());
 
@@ -1904,7 +1904,7 @@ GET https://api.example.com/3
         ]);
 
         let config = ProcessorConfig::new(&files).with_fail_fast(true);
-        let result = process_http_files_with_config(&config, &|req, v, i| mock.execute(req, v, i));
+        let result = process_http_files(&config, &|req, v, i| mock.execute(req, v, i));
 
         assert!(result.is_ok());
         let res = result.unwrap();
@@ -1928,7 +1928,7 @@ GET https://api.example.com/3
         let captured_clone = captured_verbose.clone();
 
         let config = ProcessorConfig::new(&files).with_fail_fast(true);
-        let result = process_http_files_with_config(&config, &|_req, v, _i| {
+        let result = process_http_files(&config, &|_req, v, _i| {
             *captured_clone.lock().unwrap() = Some(v);
             Ok(HttpResult {
                 request_name: None,
@@ -1983,7 +1983,7 @@ GET https://api.example.com/never
         ]);
 
         let config = ProcessorConfig::new(&files).with_fail_fast(true);
-        let result = process_http_files_with_config(&config, &|req, v, i| mock.execute(req, v, i));
+        let result = process_http_files(&config, &|req, v, i| mock.execute(req, v, i));
 
         assert!(result.is_ok());
         let res = result.unwrap();
@@ -2009,7 +2009,7 @@ GET https://api.example.com/2
         let call_count_clone = call_count.clone();
 
         let config = ProcessorConfig::new(&files).with_fail_fast(true);
-        let result = process_http_files_with_config(&config, &|_req, _v, _i| {
+        let result = process_http_files(&config, &|_req, _v, _i| {
             *call_count_clone.lock().unwrap() += 1;
             Err(anyhow::anyhow!("Network error"))
         });
@@ -2043,7 +2043,7 @@ GET https://api.example.com/final
         ]);
 
         let config = ProcessorConfig::new(&files).with_fail_fast(true);
-        let result = process_http_files_with_config(&config, &|req, v, i| mock.execute(req, v, i));
+        let result = process_http_files(&config, &|req, v, i| mock.execute(req, v, i));
 
         assert!(result.is_ok());
         let res = result.unwrap();
@@ -2079,7 +2079,7 @@ GET https://api.example.com/final
         ]);
 
         let config = ProcessorConfig::new(&files).with_fail_fast(true);
-        let result = process_http_files_with_config(&config, &|req, v, i| mock.execute(req, v, i));
+        let result = process_http_files(&config, &|req, v, i| mock.execute(req, v, i));
 
         assert!(result.is_ok());
         let res = result.unwrap();
@@ -2120,7 +2120,7 @@ GET https://api.example.com/3
 
         // fail_fast defaults to false
         let config = ProcessorConfig::new(&files);
-        let result = process_http_files_with_config(&config, &|req, v, i| mock.execute(req, v, i));
+        let result = process_http_files(&config, &|req, v, i| mock.execute(req, v, i));
 
         assert!(result.is_ok());
         let res = result.unwrap();

--- a/src/core/src/processor/executor_tests.rs
+++ b/src/core/src/processor/executor_tests.rs
@@ -3,9 +3,7 @@ use tempfile::NamedTempFile;
 
 #[cfg(test)]
 mod tests {
-    use super::super::executor::{
-        ProcessorConfig, process_http_files, process_http_files_with_executor,
-    };
+    use super::super::executor::{ProcessorConfig, process_http_files};
     use super::super::mock_executor::MockHttpExecutor;
     use super::*;
     use crate::types::{HttpRequest, HttpResult};
@@ -38,13 +36,13 @@ mod tests {
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -73,13 +71,13 @@ DELETE https://api.example.com/3
             create_success_response(None),
         ]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -107,13 +105,13 @@ DELETE https://api.example.com/3
             assertion_results: Vec::new(),
         }]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -135,13 +133,13 @@ GET https://api.example.com/named
         let mock =
             MockHttpExecutor::new(vec![create_success_response(Some("testReq".to_string()))]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -157,13 +155,13 @@ GET https://api.example.com/named
 
         let mock = MockHttpExecutor::new(vec![]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -179,13 +177,13 @@ GET https://api.example.com/named
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -200,13 +198,13 @@ GET https://api.example.com/named
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            true,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(true)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -226,13 +224,13 @@ GET https://api.example.com/named
             create_success_response(None),
         ]);
 
-        let result = process_http_files_with_executor(
-            &[path1, path2],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[path1, path2])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -254,13 +252,13 @@ Content-Type: application/json
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -282,13 +280,13 @@ Content-Type: application/json
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -321,13 +319,13 @@ OPTIONS https://api.example.com/test
         let responses: Vec<_> = (0..7).map(|_| create_success_response(None)).collect();
         let mock = MockHttpExecutor::new(responses);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -352,13 +350,13 @@ GET https://api.example.com/data
             create_success_response(None),
         ]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -389,13 +387,13 @@ GET https://api.example.com/data
             assertion_results: Vec::new(),
         }]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -416,13 +414,13 @@ GET https://api.example.com/slow
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -442,13 +440,13 @@ GET https://api.example.com/test
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -493,13 +491,13 @@ GET https://api.example.com/test
 
         let mock = MockHttpExecutor::new(vec![result_with_assertions]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -521,13 +519,13 @@ GET https://api.example.com/user
         let mock =
             MockHttpExecutor::new(vec![create_success_response(Some("getUser".to_string()))]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -563,13 +561,13 @@ GET https://api.example.com/success2
             create_success_response(None),
         ]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -594,13 +592,13 @@ Content-Type: application/json
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            true,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(true),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -619,13 +617,13 @@ Content-Type: application/json
 
         let log_base = "test_log_executor";
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            Some(log_base),
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(Some(log_base))
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -752,13 +750,13 @@ GET https://api.example.com/test
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            Some("production"),
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(Some("production"))
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -787,13 +785,13 @@ GET https://api.example.com/third
             create_success_response(None),
         ]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -833,13 +831,13 @@ GET https://api.example.com/third
             },
         ]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -857,13 +855,13 @@ GET https://api.example.com/third
 
         let mock = MockHttpExecutor::new(vec![]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -897,13 +895,13 @@ GET https://api.example.com/third
 
         let mock = MockHttpExecutor::new(vec![response]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -935,13 +933,13 @@ Content-Type: application/json
             "verboseTest".to_string(),
         ))]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -973,13 +971,13 @@ Content-Type: application/json
 
         let mock = MockHttpExecutor::new(vec![response]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1010,13 +1008,13 @@ Content-Type: application/json
 
         let mock = MockHttpExecutor::new(vec![response]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            true,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(true),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1047,13 +1045,13 @@ GET https://api.example.com/test
 
         let mock = MockHttpExecutor::new(vec![response]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1092,13 +1090,13 @@ GET https://api.example.com/test
 
         let mock = MockHttpExecutor::new(vec![response]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1124,13 +1122,13 @@ GET https://api.example.com/data
             create_success_response(None),
         ]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1152,13 +1150,13 @@ GET https://api.example.com/data
 
         let mock = MockHttpExecutor::new(vec![create_success_response(Some("setup".to_string()))]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1185,13 +1183,13 @@ GET https://api.example.com/data
             create_success_response(None),
         ]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1209,13 +1207,13 @@ GET https://api.example.com/data
         let failing_executor =
             |_req: &HttpRequest, _v: bool, _i: bool| Err(anyhow::anyhow!("Network error"));
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &failing_executor,
         );
 
@@ -1244,13 +1242,13 @@ GET https://api.example.com/data
 
         let mock = MockHttpExecutor::new(vec![response]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1279,13 +1277,13 @@ GET https://api.example.com/data
 
         let mock = MockHttpExecutor::new(vec![response]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1310,13 +1308,13 @@ GET https://api.example.com/data
             create_success_response(None),
         ]);
 
-        let result = process_http_files_with_executor(
-            &[path1, path2, path3],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[path1, path2, path3])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1334,13 +1332,13 @@ GET https://api.example.com/data
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1360,16 +1358,16 @@ GET https://api.example.com/data
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[
+        let result = process_http_files(
+            &ProcessorConfig::new(&[
                 invalid_file.to_str().unwrap().to_string(),
                 valid_file.to_str().unwrap().to_string(),
-            ],
-            false,
-            None,
-            None,
-            false,
-            false,
+            ])
+            .with_verbose(false)
+            .with_log_filename(None)
+            .with_environment(None)
+            .with_insecure(false)
+            .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1389,13 +1387,13 @@ Authorization: Bearer token123
 
         let mock = MockHttpExecutor::new(vec![create_success_response(None)]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1421,13 +1419,13 @@ Authorization: Bearer token123
 
         let mock = MockHttpExecutor::new(vec![response]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1449,13 +1447,13 @@ Content-Type: application/json
         let mock =
             MockHttpExecutor::new(vec![create_success_response(Some("myRequest".to_string()))]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            true,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(true)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1493,13 +1491,13 @@ Content-Type: application/json
             }],
         }]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1535,13 +1533,13 @@ Content-Type: application/json
             }],
         }]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1577,13 +1575,13 @@ Content-Type: application/json
             }],
         }]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1619,13 +1617,13 @@ Content-Type: application/json
             }],
         }]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1672,13 +1670,13 @@ Content-Type: application/json
             ],
         }]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1726,13 +1724,13 @@ Content-Type: application/json
             ],
         }]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1769,13 +1767,13 @@ Content-Type: application/json
             }],
         }]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 
@@ -1858,13 +1856,13 @@ GET https://api.example.com/not-found
             },
         ]);
 
-        let result = process_http_files_with_executor(
-            &[file_path],
-            false,
-            None,
-            None,
-            false,
-            false,
+        let result = process_http_files(
+            &ProcessorConfig::new(&[file_path])
+                .with_verbose(false)
+                .with_log_filename(None)
+                .with_environment(None)
+                .with_insecure(false)
+                .with_pretty_json(false),
             &|req, v, i| mock.execute(req, v, i),
         );
 

--- a/src/core/src/processor/mod.rs
+++ b/src/core/src/processor/mod.rs
@@ -4,10 +4,7 @@ mod incremental;
 pub(crate) mod incremental_loop;
 mod output;
 
-pub use executor::{
-    ProcessorConfig, default_executor, process_http_files, process_http_files_with_executor,
-    process_http_files_with_options, process_http_files_with_silent,
-};
+pub use executor::{ProcessorConfig, default_executor, process_http_files};
 
 pub use formatter::format_json_if_valid;
 

--- a/src/core/src/processor/mod.rs
+++ b/src/core/src/processor/mod.rs
@@ -5,9 +5,8 @@ pub(crate) mod incremental_loop;
 mod output;
 
 pub use executor::{
-    ProcessorConfig, process_http_files, process_http_files_with_config,
-    process_http_files_with_executor, process_http_files_with_options,
-    process_http_files_with_silent,
+    ProcessorConfig, process_http_files_with_config, process_http_files_with_executor,
+    process_http_files_with_options, process_http_files_with_silent,
 };
 
 pub use formatter::format_json_if_valid;

--- a/src/core/src/processor/mod.rs
+++ b/src/core/src/processor/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod incremental_loop;
 mod output;
 
 pub use executor::{
-    ProcessorConfig, process_http_files_with_config, process_http_files_with_executor,
+    ProcessorConfig, process_http_files, process_http_files_with_executor,
     process_http_files_with_options, process_http_files_with_silent,
 };
 

--- a/src/core/src/processor/mod.rs
+++ b/src/core/src/processor/mod.rs
@@ -5,7 +5,7 @@ pub(crate) mod incremental_loop;
 mod output;
 
 pub use executor::{
-    ProcessorConfig, process_http_files, process_http_files_with_executor,
+    ProcessorConfig, default_executor, process_http_files, process_http_files_with_executor,
     process_http_files_with_options, process_http_files_with_silent,
 };
 


### PR DESCRIPTION
## Summary

Collapses the five `process_http_files*` entry points in `core/processor` into **one** config-driven interface plus a reusable default executor. This deepens the module: the interface shrinks while the implementation absorbs the wrappers, giving one place to test.

```rust
pub fn process_http_files<F>(config: &ProcessorConfig, executor: &F) -> Result<ProcessorResults>
pub fn default_executor(request: &HttpRequest, verbose: bool, insecure: bool) -> Result<HttpResult>
```

## Motivation

`process_http_files_with_config` held the real loop; `process_http_files` (7-arg), `_with_options`, `_with_silent`, and `_with_executor` were thin wrappers that each rebuilt the same 10-field `ProcessorConfig`. The interface was nearly as wide as the implementation (shallow), and tests had to choose between five look-alike functions.

## Changes

- Remove the dead 7-arg `process_http_files` (zero callers).
- Rename the real loop `_with_config` → `process_http_files` as the single entry.
- Add `default_executor` (real blocking HTTP) so callers pass only config + the default.
- Wire the CLI to build a `ProcessorConfig` and call the unified entry.
- Migrate all 50 `_with_executor` test calls to the single interface.
- Remove the `_with_options`, `_with_silent`, `_with_executor` wrappers.

Public processor surface is now `ProcessorConfig`, `default_executor`, `process_http_files`.

## Verification

- `cargo build` (workspace) ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅ (incl. 136 processor tests)

## Notes

Six small, self-contained commits — each compiles and passes tests. No behavioural change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how the CLI processes HTTP files, with more consistent handling of options and execution.
  * Kept existing success and failure messaging unchanged while updating the underlying processing flow.
* **Refactor**
  * Simplified the request-processing path to use a single shared configuration and execution approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->