### PR TITLE
Extract shared HTTP builders for sync & async executors

### DIFF
--- a/src/core/src/runner/executor.rs
+++ b/src/core/src/runner/executor.rs
@@ -1,9 +1,10 @@
 #[cfg(not(target_arch = "wasm32"))]
+use super::http_builders::{ClientConfig, parse_method, resolve_body};
+#[cfg(not(target_arch = "wasm32"))]
 use super::response_processor::{
     build_error_result, build_success_result, extract_headers,
     should_capture_response,
 };
-use super::{encode_form_body, needs_form_encoding};
 #[cfg(not(target_arch = "wasm32"))]
 use crate::telemetry::{ConnectionErrorCategory, track_connection_error};
 #[cfg(not(target_arch = "wasm32"))]
@@ -24,25 +25,6 @@ type ResponseDetails = (Option<HashMap<String, String>>, Option<String>);
 
 #[cfg(not(target_arch = "wasm32"))]
 static CLIENT_CACHE: OnceLock<Mutex<HashMap<ClientConfig, Client>>> = OnceLock::new();
-
-#[cfg(not(target_arch = "wasm32"))]
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct ClientConfig {
-    connect_timeout_ms: u64,
-    timeout_ms: u64,
-    insecure: bool,
-}
-
-#[cfg(not(target_arch = "wasm32"))]
-impl ClientConfig {
-    fn from_request(request: &HttpRequest, insecure: bool) -> Self {
-        Self {
-            connect_timeout_ms: request.connection_timeout.unwrap_or(30_000),
-            timeout_ms: request.timeout.unwrap_or(60_000),
-            insecure,
-        }
-    }
-}
 
 #[cfg(not(target_arch = "wasm32"))]
 #[allow(private_interfaces)]
@@ -194,21 +176,13 @@ fn build_request(
     client: &Client,
     request: &HttpRequest,
 ) -> Result<reqwest::blocking::RequestBuilder> {
-    let method = request.method.to_uppercase();
-    let method = reqwest::Method::from_bytes(method.as_bytes())?;
-
-    let mut req_builder = client.request(method, &request.url);
+    let mut req_builder = client.request(parse_method(request)?, &request.url);
 
     for header in &request.headers {
         req_builder = req_builder.header(&header.name, &header.value);
     }
 
-    if let Some(ref body) = request.body {
-        let body = if needs_form_encoding(&request.headers) {
-            encode_form_body(body)
-        } else {
-            body.clone()
-        };
+    if let Some(body) = resolve_body(request) {
         req_builder = req_builder.body(body);
     }
 

--- a/src/core/src/runner/executor_async.rs
+++ b/src/core/src/runner/executor_async.rs
@@ -1,8 +1,8 @@
+use super::http_builders::{parse_method, resolve_body};
 use super::response_processor::{
     build_error_result, build_success_result, extract_headers,
     should_capture_response,
 };
-use super::{encode_form_body, needs_form_encoding};
 use crate::types::{HttpRequest, HttpResult};
 use anyhow::Result;
 use reqwest::Client;
@@ -64,14 +64,13 @@ fn build_client_async(request: &HttpRequest, insecure: bool) -> Result<Client> {
 
     #[cfg(not(target_arch = "wasm32"))]
     {
-        let connection_timeout = request.connection_timeout.unwrap_or(30_000);
-        let read_timeout = request.timeout.unwrap_or(60_000);
+        let config = super::http_builders::ClientConfig::from_request(request, insecure);
 
         client_builder = client_builder
-            .connect_timeout(std::time::Duration::from_millis(connection_timeout))
-            .timeout(std::time::Duration::from_millis(read_timeout));
+            .connect_timeout(std::time::Duration::from_millis(config.connect_timeout_ms))
+            .timeout(std::time::Duration::from_millis(config.timeout_ms));
 
-        if insecure {
+        if config.insecure {
             client_builder = client_builder
                 .danger_accept_invalid_hostnames(true)
                 .danger_accept_invalid_certs(true);
@@ -91,21 +90,13 @@ fn build_client_async(request: &HttpRequest, insecure: bool) -> Result<Client> {
 }
 
 fn build_request_async(client: &Client, request: &HttpRequest) -> Result<reqwest::RequestBuilder> {
-    let method = request.method.to_uppercase();
-    let method = reqwest::Method::from_bytes(method.as_bytes())?;
-
-    let mut req_builder = client.request(method, &request.url);
+    let mut req_builder = client.request(parse_method(request)?, &request.url);
 
     for header in &request.headers {
         req_builder = req_builder.header(&header.name, &header.value);
     }
 
-    if let Some(ref body) = request.body {
-        let body = if needs_form_encoding(&request.headers) {
-            encode_form_body(body)
-        } else {
-            body.clone()
-        };
+    if let Some(body) = resolve_body(request) {
         req_builder = req_builder.body(body);
     }
 

--- a/src/core/src/runner/http_builders.rs
+++ b/src/core/src/runner/http_builders.rs
@@ -1,0 +1,46 @@
+use super::{encode_form_body, needs_form_encoding};
+use crate::types::HttpRequest;
+use anyhow::Result;
+
+/// Parse the request's method string into a [`reqwest::Method`].
+///
+/// Shared by the blocking and async executors so method handling lives in one place.
+pub(crate) fn parse_method(request: &HttpRequest) -> Result<reqwest::Method> {
+    let method = request.method.to_uppercase();
+    Ok(reqwest::Method::from_bytes(method.as_bytes())?)
+}
+
+/// Resolve the request body, applying form-encoding when the headers call for it.
+///
+/// Shared by the blocking and async executors so body handling lives in one place.
+pub(crate) fn resolve_body(request: &HttpRequest) -> Option<String> {
+    request.body.as_ref().map(|body| {
+        if needs_form_encoding(&request.headers) {
+            encode_form_body(body)
+        } else {
+            body.clone()
+        }
+    })
+}
+
+/// Client configuration derived from a request: connection/read timeouts and TLS policy.
+///
+/// Shared by the blocking and async executors so timeout/TLS handling lives in one place.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct ClientConfig {
+    pub(crate) connect_timeout_ms: u64,
+    pub(crate) timeout_ms: u64,
+    pub(crate) insecure: bool,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl ClientConfig {
+    pub(crate) fn from_request(request: &HttpRequest, insecure: bool) -> Self {
+        Self {
+            connect_timeout_ms: request.connection_timeout.unwrap_or(30_000),
+            timeout_ms: request.timeout.unwrap_or(60_000),
+            insecure,
+        }
+    }
+}

--- a/src/core/src/runner/http_builders.rs
+++ b/src/core/src/runner/http_builders.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 /// Parse the request's method string into a [`reqwest::Method`].
 ///
 /// Shared by the blocking and async executors so method handling lives in one place.
-pub(crate) fn parse_method(request: &HttpRequest) -> Result<reqwest::Method> {
+pub(super) fn parse_method(request: &HttpRequest) -> Result<reqwest::Method> {
     let method = request.method.to_uppercase();
     Ok(reqwest::Method::from_bytes(method.as_bytes())?)
 }
@@ -13,7 +13,7 @@ pub(crate) fn parse_method(request: &HttpRequest) -> Result<reqwest::Method> {
 /// Resolve the request body, applying form-encoding when the headers call for it.
 ///
 /// Shared by the blocking and async executors so body handling lives in one place.
-pub(crate) fn resolve_body(request: &HttpRequest) -> Option<String> {
+pub(super) fn resolve_body(request: &HttpRequest) -> Option<String> {
     request.body.as_ref().map(|body| {
         if needs_form_encoding(&request.headers) {
             encode_form_body(body)
@@ -28,15 +28,15 @@ pub(crate) fn resolve_body(request: &HttpRequest) -> Option<String> {
 /// Shared by the blocking and async executors so timeout/TLS handling lives in one place.
 #[cfg(not(target_arch = "wasm32"))]
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-pub(crate) struct ClientConfig {
-    pub(crate) connect_timeout_ms: u64,
-    pub(crate) timeout_ms: u64,
-    pub(crate) insecure: bool,
+pub(super) struct ClientConfig {
+    pub(super) connect_timeout_ms: u64,
+    pub(super) timeout_ms: u64,
+    pub(super) insecure: bool,
 }
 
 #[cfg(not(target_arch = "wasm32"))]
 impl ClientConfig {
-    pub(crate) fn from_request(request: &HttpRequest, insecure: bool) -> Self {
+    pub(super) fn from_request(request: &HttpRequest, insecure: bool) -> Self {
         Self {
             connect_timeout_ms: request.connection_timeout.unwrap_or(30_000),
             timeout_ms: request.timeout.unwrap_or(60_000),

--- a/src/core/src/runner/mod.rs
+++ b/src/core/src/runner/mod.rs
@@ -1,4 +1,5 @@
 mod executor;
+mod http_builders;
 mod incremental_async;
 mod response_processor;
 mod url_encoding;


### PR DESCRIPTION
## Summary

The blocking (`runner/executor.rs`) and async (`runner/executor_async.rs`) executors duplicated the same type-agnostic request/client construction logic, differing only by `reqwest::blocking` vs `reqwest` types and `.await`. This extracts the shared pieces into a new `runner/http_builders.rs` so they live in one place.

## What's shared now

- **`parse_method(request)`** — method string → `reqwest::Method`
- **`resolve_body(request)`** — request body + form-encoding decision
- **`ClientConfig::from_request`** — connection/read timeouts + TLS policy (non-wasm)

Both `build_request`/`build_request_async` and `build_client*` now call these helpers, so method parsing, body/form-encoding, and timeout/TLS configuration are defined once.

## Why the two adapters remain

The blocking and async reqwest clients are distinct types (`reqwest::blocking::Client` vs `reqwest::Client`), and the blocking client intentionally avoids needing a tokio runtime on native. They can't collapse into one implementation, so the two thin adapters stay — this is the "two adapters justify the seam" outcome. Only the genuinely shared, type-agnostic logic was extracted.

## Verification

- `cargo build` clean (no warnings); 93 runner tests pass (both executors, real TCP listeners)
- `cargo test --workspace` ✅ (1005+ core tests) and `cargo clippy --workspace --all-targets -- -D warnings` ✅
- wasm: confirmed this change adds **zero** new errors. `ClientConfig` is gated to non-wasm (it is only used there), and `parse_method`/`resolve_body` use only wasm-available APIs.

Net **-34 lines** across the two executors; the duplication is consolidated into the shared module. GUI/TUI/CLI untouched.

## Note (out of scope)

`httprunner-core` does not currently compile standalone for `wasm32-unknown-unknown` — `runner/mod.rs` re-exports `crate::processor::RequestProcessingResult`, but `processor` is gated off on wasm. This is **pre-existing** (reproduced on a clean `main`) and unrelated to this PR. Happy to address it separately.