### PR TITLE
Share .http file discovery between GUI and TUI via Core library

### DIFF
--- a/src/core/src/discovery/mod.rs
+++ b/src/core/src/discovery/mod.rs
@@ -2,6 +2,9 @@ mod scanner;
 
 pub use scanner::run_discovery_mode;
 
+#[cfg(not(target_arch = "wasm32"))]
+pub use scanner::discover_http_file_paths;
+
 #[cfg(test)]
 pub(crate) use scanner::discover_http_files;
 

--- a/src/core/src/discovery/scanner.rs
+++ b/src/core/src/discovery/scanner.rs
@@ -2,6 +2,38 @@ use crate::colors;
 use anyhow::Result;
 use walkdir::WalkDir;
 
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::{Path, PathBuf};
+
+/// Recursively discover `.http` files under `root`, returned in sorted order.
+///
+/// `on_progress` is called with the running count as each file is found, letting
+/// UIs report discovery progress. Shared by the GUI and TUI file trees so the
+/// walk/filter/sort logic lives in one place.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn discover_http_file_paths<F>(root: &Path, mut on_progress: F) -> Vec<PathBuf>
+where
+    F: FnMut(usize),
+{
+    let mut files = Vec::new();
+
+    for entry in WalkDir::new(root)
+        .follow_links(true)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        if entry.file_type().is_file()
+            && entry.path().extension().is_some_and(|ext| ext == "http")
+        {
+            files.push(entry.path().to_path_buf());
+            on_progress(files.len());
+        }
+    }
+
+    files.sort();
+    files
+}
+
 pub(crate) fn discover_http_files(dir_path: &str) -> Result<Vec<String>> {
     let mut files = Vec::new();
 

--- a/src/core/src/discovery/tests.rs
+++ b/src/core/src/discovery/tests.rs
@@ -23,6 +23,32 @@ fn discover_http_files_finds_nested_files() {
 }
 
 #[test]
+fn discover_http_file_paths_returns_sorted_with_progress() {
+    let temp = tempdir().unwrap();
+    let nested = temp.path().join("nested");
+    fs::create_dir(&nested).unwrap();
+
+    fs::write(temp.path().join("b.http"), "GET http://example.com").unwrap();
+    fs::write(nested.join("a.http"), "GET http://example.com").unwrap();
+    fs::write(temp.path().join("ignore.txt"), "noop").unwrap();
+
+    let mut progress = Vec::new();
+    let files = discover_http_file_paths(temp.path(), |count| progress.push(count));
+
+    assert_eq!(files.len(), 2);
+    let mut sorted = files.clone();
+    sorted.sort();
+    assert_eq!(files, sorted, "paths should be returned sorted");
+    assert!(
+        files
+            .iter()
+            .all(|p| p.extension().is_some_and(|ext| ext == "http")),
+        "only .http files should be returned"
+    );
+    assert_eq!(progress, vec![1, 2], "progress should report each file found");
+}
+
+#[test]
 fn discover_http_files_returns_empty_when_none_found() {
     let temp = tempdir().unwrap();
     fs::write(temp.path().join("file.txt"), "noop").unwrap();

--- a/src/gui/Cargo.toml
+++ b/src/gui/Cargo.toml
@@ -44,7 +44,6 @@ egui_code_editor = "0.2.23"
 # Platform-specific dependencies
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 rfd = { workspace = true }
-walkdir = { workspace = true }
 
 # Web-specific dependencies
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/gui/src/file_tree.rs
+++ b/src/gui/src/file_tree.rs
@@ -2,8 +2,6 @@ use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 #[cfg(not(target_arch = "wasm32"))]
 use std::thread;
-#[cfg(not(target_arch = "wasm32"))]
-use walkdir::WalkDir;
 
 pub struct FileTree {
     root_path: PathBuf,
@@ -29,25 +27,13 @@ impl FileTree {
 
             // Start async discovery in background thread
             thread::spawn(move || {
-                let mut temp_files = Vec::new();
-
-                for entry in WalkDir::new(&path_clone)
-                    .follow_links(true)
-                    .into_iter()
-                    .filter_map(|e| e.ok())
-                {
-                    if entry.file_type().is_file()
-                        && let Some(ext) = entry.path().extension()
-                        && ext == "http"
-                    {
-                        temp_files.push(entry.path().to_path_buf());
-                        if let Ok(mut count) = count_clone.lock() {
-                            *count = temp_files.len();
+                let temp_files =
+                    httprunner_core::discovery::discover_http_file_paths(&path_clone, |count| {
+                        if let Ok(mut c) = count_clone.lock() {
+                            *c = count;
                         }
-                    }
-                }
+                    });
 
-                temp_files.sort();
                 if let Ok(mut files) = files_clone.lock() {
                     *files = temp_files;
                 }

--- a/src/tui/Cargo.toml
+++ b/src/tui/Cargo.toml
@@ -23,7 +23,6 @@ path = "src/main.rs"
 [dependencies]
 httprunner-core = { path = "../core" }
 anyhow = { workspace = true }
-walkdir = { workspace = true }
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = { workspace = true }
 dirs = "6.0"

--- a/src/tui/src/file_tree.rs
+++ b/src/tui/src/file_tree.rs
@@ -2,7 +2,6 @@ use crossterm::event::{KeyCode, KeyEvent};
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::thread;
-use walkdir::WalkDir;
 
 pub struct FileTree {
     root: PathBuf,
@@ -26,23 +25,13 @@ impl FileTree {
 
         // Start async discovery in background thread
         thread::spawn(move || {
-            let mut temp_files = Vec::new();
-
-            for entry in WalkDir::new(&path_clone)
-                .follow_links(true)
-                .into_iter()
-                .filter_map(|e| e.ok())
-            {
-                let path = entry.path();
-                if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("http") {
-                    temp_files.push(path.to_path_buf());
-                    if let Ok(mut count) = count_clone.lock() {
-                        *count = temp_files.len();
+            let temp_files =
+                httprunner_core::discovery::discover_http_file_paths(&path_clone, |count| {
+                    if let Ok(mut c) = count_clone.lock() {
+                        *c = count;
                     }
-                }
-            }
+                });
 
-            temp_files.sort();
             if let Ok(mut files) = files_clone.lock() {
                 *files = temp_files;
             }


### PR DESCRIPTION
## Summary

The GUI and TUI file trees each reimplemented the same `.http` discovery walk (`WalkDir` → filter by `.http` extension → track a running count → sort). This extracts that logic into core as `discovery::discover_http_file_paths`, so both front-ends share one tested implementation and keep only their thread + state orchestration.

## What changed

- **core**: new `discovery::discover_http_file_paths(root, on_progress) -> Vec<PathBuf>` — recursively finds `.http` files, reports progress per file via a callback, and returns them sorted. Gated to non-wasm (filesystem walk). Unit-tested for sorting, filtering, and progress.
- **gui** / **tui**: `FileTree` discovery threads now call the core helper instead of duplicating the `WalkDir` loop. `walkdir` removed from both crates' dependencies (no longer used there).

## Scope notes (Candidate 4)

The PRD envisioned a broader "core session" owning discovery, environment resolution, the run, and a shared result DTO. Verifying against the current code:

- **Environment resolution** is *already* shared — GUI/TUI both call `core::environment::{find,parse,save}_environment_file`. No change needed.
- **The run path** is *already* shared — both call `core::processor::process_http_file_incremental_with_executor` (from the pipeline unification).
- **Discovery** — addressed here.
- **Result DTO** — intentionally **not** unified. The GUI and TUI `ExecutionResult` types have diverged for real UI reasons: the GUI carries rich `Failure(FailureResult { status, bodies, assertions })` plus a `Running` variant and serde persistence, while the TUI uses a simple `Failure { error }` plus a `Skipped` variant and no persistence. Forcing a shared DTO would mean rewriting both renderers for little benefit, so it's left as-is.

Net result: discovery, environment, and execution now all live in core; only the deliberately UI-specific result presentation stays in the front-ends.

## Verification

- `cargo test --workspace` ✅ (1006 core tests incl. the new discovery test; GUI/TUI tests pass)
- `cargo clippy --workspace --all-targets -- -D warnings` ✅
- `cargo build` clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved file discovery for HTTP files, including nested folders, sorted results, and live progress updates during scanning.
  * Added support for this behavior in both the GUI and TUI file trees on non-web targets.

* **Bug Fixes**
  * Restricted the new file discovery path to compatible platforms, avoiding use in web-based builds.
  * Kept discovery results limited to `.http` files while ignoring unrelated files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->